### PR TITLE
chore: Backend 환경 설정 구현 및 DB 설정 완료

### DIFF
--- a/backend/src/@types/express/index.d.ts
+++ b/backend/src/@types/express/index.d.ts
@@ -4,6 +4,9 @@ declare module 'express' {
   export interface Request {
     body: {
       user: IUser;
+      nickname: string;
+      email: string;
+      type: string;
     };
   }
 }

--- a/backend/src/@types/express/index.d.ts
+++ b/backend/src/@types/express/index.d.ts
@@ -1,4 +1,6 @@
+import { IChannel } from '@daos/Channel';
 import { IUser } from 'src/model/User';
+import { IWorkspace } from 'src/model/Workspace';
 
 declare module 'express' {
   export interface Request {
@@ -7,6 +9,11 @@ declare module 'express' {
       nickname: string;
       email: string;
       type: string;
+      workspace: IWorkspace;
+      name: string;
+      profile: string;
+      channel: IChannel;
+      description: string;
     };
   }
 }

--- a/backend/src/@types/express/index.d.ts
+++ b/backend/src/@types/express/index.d.ts
@@ -1,4 +1,4 @@
-import { IChannel } from '@daos/Channel';
+import { IChannel } from 'src/model/Channel';
 import { IUser } from 'src/model/User';
 import { IWorkspace } from 'src/model/Workspace';
 

--- a/backend/src/Server.ts
+++ b/backend/src/Server.ts
@@ -36,7 +36,6 @@ app.use('/api', BaseRouter);
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 
 app.use((err: Error, req: Request, res: Response) => {
-
   logger.err(err, true);
   return res.status(BAD_REQUEST).json({
     error: err.message,

--- a/backend/src/Server.ts
+++ b/backend/src/Server.ts
@@ -6,7 +6,7 @@ import helmet from 'helmet';
 import express, { Request, Response } from 'express';
 import StatusCodes from 'http-status-codes';
 import 'express-async-errors';
-import logger from '@shared/Logger';
+import logger from './shared/Logger';
 import BaseRouter from './routes';
 
 const app = express();

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,8 +1,8 @@
 import './pre-start'; // Must be the first import
-import app from '@server';
-import logger from '@shared/Logger';
-import 'reflect-metadata';
 import { createConnection } from 'typeorm';
+import app from './Server';
+import logger from './shared/Logger';
+import 'reflect-metadata';
 import connectionOptions from './ormconfig';
 
 createConnection(connectionOptions)

--- a/backend/src/model/Channel.ts
+++ b/backend/src/model/Channel.ts
@@ -1,5 +1,13 @@
 /* eslint-disable import/prefer-default-export */
-import { Entity, PrimaryGeneratedColumn, Column, ManyToOne } from 'typeorm';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  ManyToMany,
+  JoinTable,
+} from 'typeorm';
+import { User } from './User';
 import { Workspace } from './Workspace';
 
 @Entity()
@@ -18,4 +26,8 @@ export class Channel {
 
   @ManyToOne(() => Workspace, (workspace) => workspace.channels)
   workspace!: Workspace;
+
+  @ManyToMany(() => User)
+  @JoinTable()
+  users!: User[];
 }

--- a/backend/src/model/Channel.ts
+++ b/backend/src/model/Channel.ts
@@ -10,6 +10,16 @@ import {
 import { User } from './User';
 import { Workspace } from './Workspace';
 
+export interface IChannel {
+  id: number;
+
+  name: string;
+
+  type: string;
+
+  description: string;
+}
+
 @Entity()
 export class Channel {
   @PrimaryGeneratedColumn()

--- a/backend/src/model/User.ts
+++ b/backend/src/model/User.ts
@@ -27,7 +27,7 @@ export class User implements IUser {
 
   @OneToMany(
     () => UserHasWorkspace,
-    (userHasWorkspace) => userHasWorkspace.user,
+    (userHasWorkspace) => userHasWorkspace.user
   )
   userHasWorkspaces!: UserHasWorkspace[];
 }

--- a/backend/src/model/Workspace.ts
+++ b/backend/src/model/Workspace.ts
@@ -3,8 +3,16 @@ import { Entity, PrimaryGeneratedColumn, Column, OneToMany } from 'typeorm';
 import { Channel } from './Channel';
 import { UserHasWorkspace } from './UserHasWorkspace';
 
+export interface IWorkspace {
+  id: number;
+
+  profile: string;
+
+  name: string;
+}
+
 @Entity()
-export class Workspace {
+export class Workspace implements IWorkspace {
   @PrimaryGeneratedColumn()
   id!: number;
 

--- a/backend/src/model/Workspace.ts
+++ b/backend/src/model/Workspace.ts
@@ -19,7 +19,7 @@ export class Workspace {
 
   @OneToMany(
     () => UserHasWorkspace,
-    (userHasWorkspace) => userHasWorkspace.workspace,
+    (userHasWorkspace) => userHasWorkspace.workspace
   )
   userHasWorkspaces!: UserHasWorkspace[];
 }

--- a/backend/src/ormconfig.ts
+++ b/backend/src/ormconfig.ts
@@ -3,6 +3,8 @@ import { ConnectionOptions } from 'typeorm';
 
 dotenv.config();
 
+const entitiyPath: string = process.env.DB_ENTITY_PATH || 'src/model/*.ts';
+
 const ormconfig: ConnectionOptions = {
   type: 'mysql',
   host: process.env.DB_HOST,
@@ -12,9 +14,7 @@ const ormconfig: ConnectionOptions = {
   database: process.env.DB_DATABASE,
   synchronize: true,
   logging: false,
-  entities: ['dist/model/*.js'],
-  // start:dev 은 아래것으로 하고 start는 위에 것으로 해야댐
-  // entities: ['src/model/*.ts'],
+  entities: [entitiyPath],
 };
 
 export default ormconfig;

--- a/backend/src/ormconfig.ts
+++ b/backend/src/ormconfig.ts
@@ -12,7 +12,9 @@ const ormconfig: ConnectionOptions = {
   database: process.env.DB_DATABASE,
   synchronize: true,
   logging: false,
-  entities: ['**/dist/model/*{.ts,.js}', '**/src/model/*{.ts,.js}'],
+  entities: ['dist/model/*.js'],
+  // start:dev 은 아래것으로 하고 start는 위에 것으로 해야댐
+  // entities: ['src/model/*.ts'],
 };
 
 export default ormconfig;

--- a/backend/src/repository/ChannelRepository.ts
+++ b/backend/src/repository/ChannelRepository.ts
@@ -1,0 +1,5 @@
+import { Channel } from '@daos/Channel';
+import { EntityRepository, Repository } from 'typeorm';
+
+@EntityRepository(Channel)
+export default class ChannelRepository extends Repository<Channel> {}

--- a/backend/src/repository/ChannelRepository.ts
+++ b/backend/src/repository/ChannelRepository.ts
@@ -1,5 +1,5 @@
-import { Channel } from '@daos/Channel';
 import { EntityRepository, Repository } from 'typeorm';
+import { Channel } from '../model/Channel';
 
 @EntityRepository(Channel)
 export default class ChannelRepository extends Repository<Channel> {}

--- a/backend/src/repository/UserRepository.ts
+++ b/backend/src/repository/UserRepository.ts
@@ -1,5 +1,5 @@
-import { User } from '@daos/User';
 import { EntityRepository, Repository } from 'typeorm';
+import { User } from '../model/User';
 
 @EntityRepository(User)
 export default class UserRepository extends Repository<User> {}

--- a/backend/src/repository/WorkspaceRepository.ts
+++ b/backend/src/repository/WorkspaceRepository.ts
@@ -1,5 +1,5 @@
-import { Workspace } from '@daos/Workspace';
 import { EntityRepository, Repository } from 'typeorm';
+import { Workspace } from '../model/Workspace';
 
 @EntityRepository(Workspace)
 export default class WorkspaceRepository extends Repository<Workspace> {}

--- a/backend/src/routes/ChannelController.ts
+++ b/backend/src/routes/ChannelController.ts
@@ -1,0 +1,18 @@
+import { Router } from 'express';
+import {
+  getAllChannels,
+  getOneChannel,
+  addOneChannel,
+  updateOneChannel,
+  deleteOneChannel,
+} from '../service/ChannelService';
+
+const channelRouter = Router();
+
+channelRouter.get('/all', getAllChannels);
+channelRouter.get('/one/:id', getOneChannel);
+channelRouter.post('/add', addOneChannel);
+channelRouter.put('/update/:id', updateOneChannel);
+channelRouter.delete('/delete/:id', deleteOneChannel);
+
+export default channelRouter;

--- a/backend/src/routes/WorkspaceController.ts
+++ b/backend/src/routes/WorkspaceController.ts
@@ -1,40 +1,18 @@
-// import StatusCodes from 'http-status-codes';
-// import { Request, Response } from 'express';
-// import { WorkspaceService } from 'src/service/WorkspaceService';
-// import paramMissingError from '@shared/constants';
-//
-// const { BAD_REQUEST, CREATED, OK } = StatusCodes;
-//
-// export async function getAllWorkspaces(req: Request, res: Response) {
-//   const workspaces = await WorkspaceService.find();
-//   return res.status(OK).json({ workspaces });
-// }
-//
-// export async function addOneWorkspace(req: Request, res: Response) {
-//   const { workspace } = req.body;
-//   if (!workspace) {
-//     return res.status(BAD_REQUEST).json({
-//       error: paramMissingError,
-//     });
-//   }
-//   await WorkspaceService.save(workspace);
-//   return res.status(CREATED).end();
-// }
-//
-// export async function updateOneWorkspace(req: Request, res: Response) {
-//   const { workspace } = req.body;
-//   if (!workspace) {
-//     return res.status(BAD_REQUEST).json({
-//       error: paramMissingError,
-//     });
-//   }
-//   workspace.id = Number(workspace.id);
-//   await WorkspaceService.update(workspace);
-//   return res.status(OK).end();
-// }
-//
-// export async function deleteOneWorkspace(req: Request, res: Response) {
-//   const { id } = req.params;
-//   await WorkspaceService.delete(Number(id));
-//   return res.status(OK).end();
-// }
+import { Router } from 'express';
+import {
+  getAllWorkspaces,
+  getOneWorkspace,
+  addOneWorkspace,
+  updateOneWorkspace,
+  deleteOneWorkspace,
+} from '../service/WorkspaceService';
+
+const workspaceRouter = Router();
+
+workspaceRouter.get('/all', getAllWorkspaces);
+workspaceRouter.get('/one/:id', getOneWorkspace);
+workspaceRouter.post('/add', addOneWorkspace);
+workspaceRouter.put('/update/:id', updateOneWorkspace);
+workspaceRouter.delete('/delete/:id', deleteOneWorkspace);
+
+export default workspaceRouter;

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -1,7 +1,11 @@
 import { Router } from 'express';
+import channelRouter from './ChannelController';
 import userRouter from './UserController';
+import workspaceRouter from './WorkspaceController';
 
 const baseRouter = Router();
 baseRouter.use('/users', userRouter);
+baseRouter.use('/workspace', workspaceRouter);
+baseRouter.use('/channel', channelRouter);
 
 export default baseRouter;

--- a/backend/src/service/ChannelService.ts
+++ b/backend/src/service/ChannelService.ts
@@ -1,8 +1,8 @@
 import StatusCodes from 'http-status-codes';
 import { Request, Response } from 'express';
-import paramMissingError from '@shared/constants';
 import { getCustomRepository } from 'typeorm';
-import ChannelRepository from 'src/repository/ChannelRepository';
+import ChannelRepository from '../repository/ChannelRepository';
+import paramMissingError from '../shared/constants';
 
 const { BAD_REQUEST, CREATED, OK } = StatusCodes;
 

--- a/backend/src/service/ChannelService.ts
+++ b/backend/src/service/ChannelService.ts
@@ -1,0 +1,69 @@
+import StatusCodes from 'http-status-codes';
+import { Request, Response } from 'express';
+import paramMissingError from '@shared/constants';
+import { getCustomRepository } from 'typeorm';
+import ChannelRepository from 'src/repository/ChannelRepository';
+
+const { BAD_REQUEST, CREATED, OK } = StatusCodes;
+
+export async function getAllChannels(req: Request, res: Response) {
+  const channels = await getCustomRepository(ChannelRepository).find({
+    relations: ['workspace'],
+  });
+  return res.status(OK).json({ channels });
+}
+
+export async function getOneChannel(req: Request, res: Response) {
+  const { id } = req.params;
+  try {
+    const channel = await getCustomRepository(ChannelRepository).findOne(id);
+    return res.status(OK).json({ channel });
+  } catch (e) {
+    return res.status(BAD_REQUEST).json(e);
+  }
+}
+
+export async function addOneChannel(req: Request, res: Response) {
+  const { channel } = req.body;
+  if (!channel) {
+    return res.status(BAD_REQUEST).json({
+      error: paramMissingError,
+    });
+  }
+  await getCustomRepository(ChannelRepository).save(channel);
+  return res.status(CREATED).end();
+}
+
+export async function updateOneChannel(req: Request, res: Response) {
+  const { id } = req.params;
+  const { name, type, description } = req.body;
+  try {
+    if (Object.keys(req.body).length === 0)
+      throw new Error('no channel data in body');
+    const channelById = await getCustomRepository(
+      ChannelRepository
+    ).findOneOrFail(id);
+    channelById.name = name || channelById.name;
+    channelById.type = type || channelById.type;
+    channelById.description = description || channelById.description;
+    const channel = await getCustomRepository(ChannelRepository).save(
+      channelById
+    );
+    return res.status(OK).json({ channel });
+  } catch (e) {
+    return res.status(BAD_REQUEST).json(e);
+  }
+}
+
+export async function deleteOneChannel(req: Request, res: Response) {
+  try {
+    const { id } = req.params;
+    const channel = await getCustomRepository(ChannelRepository).findOneOrFail(
+      id
+    );
+    await getCustomRepository(ChannelRepository).remove(channel);
+    return res.status(OK).end();
+  } catch (e) {
+    return res.status(BAD_REQUEST).json(e);
+  }
+}

--- a/backend/src/service/WorkspaceService.ts
+++ b/backend/src/service/WorkspaceService.ts
@@ -1,8 +1,8 @@
 import StatusCodes from 'http-status-codes';
 import { Request, Response } from 'express';
-import paramMissingError from '@shared/constants';
 import { getCustomRepository } from 'typeorm';
-import WorkspaceRepository from 'src/repository/WorkspaceRepository';
+import WorkspaceRepository from '../repository/WorkspaceRepository';
+import paramMissingError from '../shared/constants';
 
 const { BAD_REQUEST, CREATED, OK } = StatusCodes;
 

--- a/backend/src/service/WorkspaceService.ts
+++ b/backend/src/service/WorkspaceService.ts
@@ -1,0 +1,68 @@
+import StatusCodes from 'http-status-codes';
+import { Request, Response } from 'express';
+import paramMissingError from '@shared/constants';
+import { getCustomRepository } from 'typeorm';
+import WorkspaceRepository from 'src/repository/WorkspaceRepository';
+
+const { BAD_REQUEST, CREATED, OK } = StatusCodes;
+
+export async function getAllWorkspaces(req: Request, res: Response) {
+  const workspaces = await getCustomRepository(WorkspaceRepository).find();
+  return res.status(OK).json({ workspaces });
+}
+
+export async function getOneWorkspace(req: Request, res: Response) {
+  const { id } = req.params;
+  try {
+    const workspace = await getCustomRepository(WorkspaceRepository).findOne(
+      id
+    );
+    return res.status(OK).json({ workspace });
+  } catch (e) {
+    return res.status(BAD_REQUEST).json(e);
+  }
+}
+
+export async function addOneWorkspace(req: Request, res: Response) {
+  const { workspace } = req.body;
+  if (!workspace) {
+    return res.status(BAD_REQUEST).json({
+      error: paramMissingError,
+    });
+  }
+  await getCustomRepository(WorkspaceRepository).save(workspace);
+  return res.status(CREATED).end();
+}
+
+export async function updateOneWorkspace(req: Request, res: Response) {
+  const { id } = req.params;
+  const { profile, name } = req.body;
+  try {
+    if (Object.keys(req.body).length === 0)
+      throw new Error('no workspace data in body');
+    const workspaceById = await getCustomRepository(
+      WorkspaceRepository
+    ).findOneOrFail(id);
+    workspaceById.profile = profile || workspaceById.profile;
+    workspaceById.name = name || workspaceById.name;
+    const workspace = await getCustomRepository(WorkspaceRepository).save(
+      workspaceById
+    );
+    return res.status(OK).json({ workspace });
+  } catch (e) {
+    return res.status(BAD_REQUEST).json(e);
+  }
+}
+
+export async function deleteOneWorkspace(req: Request, res: Response) {
+  try {
+    const { id } = req.params;
+    const workspace = await getCustomRepository(
+      WorkspaceRepository
+    ).findOneOrFail(id);
+    await getCustomRepository(WorkspaceRepository).remove(workspace);
+    return res.status(OK).end();
+  } catch (e) {
+    return res.status(BAD_REQUEST).json(e);
+  }
+}


### PR DESCRIPTION
## 📃 PR 제목
Feature/db 빌드가능, DB 설정
## 📃 작업 목록
- [x] 빌드시에 에러가 생기는 것들 잡고 빌드된거 실행까지 가능
- [x] Channel, Workspace에 대한 DB 설정과 그에 대한 CRUD 까지 가능합니다.

## 📃 주의 사항

request.body로 부터 데이터를 얻어오기 위해서는 @types/express/index.d.ts 파일에서 body로부터의 데이터가 가질 수 있는 타입들을 명시해줘야 가능합니다.

- 빌드를 하고 run start로 실행할거면 ormconfig.ts 파일에 entitiy를 어떤걸 읽을지 수정해야 합니다. ```entities: ['dist/model/*.js'],```는 빌드된 것에서 js로 컴파일링된 엔티티만 읽어올 수 있도록 ```dist/model.*js```만 들어가야합니다.
- start:dev는 tsc로 컴파일을 하지 않고 ts-node로 바로 읽고 실행하기 때문에 ormconfig.ts 파일에 entitiy를 ts 파일들을 바로 읽도록 수정해야 합니다. ormconfig.ts 파일에 ```entities: ['src/model/*.ts'],```로 해야 합니다.

## 📃 추가 메모 사항

typeorm에서 객체를 읽어올 때 연관테이블까지도 읽어오기 위해서는 ```getCustomRepository(ChannelRepository).find({
    relations: ['workspace'],
  });```와 같이 안에 relations로 어떤 연관객체를 읽어올지 명시해줘야한다.