### PR TITLE
feat: 채널별 라우팅과 채널 참가하기

### DIFF
--- a/backend/src/@types/express/index.d.ts
+++ b/backend/src/@types/express/index.d.ts
@@ -14,6 +14,9 @@ declare module 'express' {
       profile: string;
       channel: IChannel;
       description: string;
+
+      userId: string;
+      channelId: string;
     };
   }
 }

--- a/backend/src/@types/express/index.d.ts
+++ b/backend/src/@types/express/index.d.ts
@@ -17,6 +17,7 @@ declare module 'express' {
 
       userId: string;
       channelId: string;
+      workspaceId: string;
     };
   }
 }

--- a/backend/src/model/Channel.ts
+++ b/backend/src/model/Channel.ts
@@ -7,7 +7,7 @@ import {
   ManyToMany,
   JoinTable,
 } from 'typeorm';
-import { User } from './User';
+import { UserHasWorkspace } from './UserHasWorkspace';
 import { Workspace } from './Workspace';
 
 export interface IChannel {
@@ -37,7 +37,7 @@ export class Channel {
   @ManyToOne(() => Workspace, (workspace) => workspace.channels)
   workspace!: Workspace;
 
-  @ManyToMany(() => User)
+  @ManyToMany(() => UserHasWorkspace)
   @JoinTable()
-  users!: User[];
+  userHasWorkspaces!: UserHasWorkspace[];
 }

--- a/backend/src/model/Reply.ts
+++ b/backend/src/model/Reply.ts
@@ -1,14 +1,6 @@
 /* eslint-disable import/prefer-default-export */
-import {
-  Entity,
-  PrimaryGeneratedColumn,
-  Column,
-  ManyToOne,
-  OneToOne,
-  JoinColumn,
-} from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne } from 'typeorm';
 import { Thread } from './Thread';
-import { User } from './User';
 
 @Entity()
 export class Reply {
@@ -23,8 +15,4 @@ export class Reply {
 
   @ManyToOne(() => Thread, (thread) => thread.channel)
   thread!: Thread;
-
-  @OneToOne(() => User)
-  @JoinColumn()
-  user!: User;
 }

--- a/backend/src/model/Thread.ts
+++ b/backend/src/model/Thread.ts
@@ -8,7 +8,7 @@ import {
   JoinColumn,
 } from 'typeorm';
 import { Channel } from './Channel';
-import { User } from './User';
+import { UserHasWorkspace } from './UserHasWorkspace';
 
 @Entity()
 export class Thread {
@@ -24,7 +24,7 @@ export class Thread {
   @ManyToOne(() => Channel, (channel) => channel.workspace)
   channel!: Channel;
 
-  @OneToOne(() => User)
+  @OneToOne(() => UserHasWorkspace)
   @JoinColumn()
-  user!: User;
+  userHasWorkspace!: UserHasWorkspace;
 }

--- a/backend/src/model/UserHasWorkspace.ts
+++ b/backend/src/model/UserHasWorkspace.ts
@@ -3,6 +3,14 @@ import { Entity, PrimaryGeneratedColumn, Column, ManyToOne } from 'typeorm';
 import { User } from './User';
 import { Workspace } from './Workspace';
 
+export interface IUserHasWorkspace {
+  id: number;
+
+  profile: string;
+
+  name: string;
+}
+
 @Entity()
 export class UserHasWorkspace {
   @PrimaryGeneratedColumn()
@@ -13,6 +21,12 @@ export class UserHasWorkspace {
 
   @Column()
   name!: string;
+
+  @Column({ nullable: true })
+  workspaceId!: number;
+
+  @Column({ nullable: true })
+  userId!: number;
 
   @ManyToOne(() => Workspace, (workspace) => workspace.userHasWorkspaces)
   workspace!: Workspace;

--- a/backend/src/repository/ChannelRepository.ts
+++ b/backend/src/repository/ChannelRepository.ts
@@ -46,4 +46,15 @@ export default class ChannelRepository extends Repository<Channel> {
       where: [{ type: 'public', ...likeQuery }],
     });
   }
+
+  findChannelsThatUserIn(userId: string) {
+    return this.query(
+      `
+        select * from booslack.channel
+            where booslack.channel.id in (
+                select channelId from booslack.channel_users_user
+                where userId = ${userId})
+    `,
+    );
+  }
 }

--- a/backend/src/repository/ChannelRepository.ts
+++ b/backend/src/repository/ChannelRepository.ts
@@ -47,13 +47,16 @@ export default class ChannelRepository extends Repository<Channel> {
     });
   }
 
-  findChannelsThatUserIn(userId: string) {
+  findChannelsThatUserIn(userId: string, workspaceId: string) {
     return this.query(
       `
-        select * from booslack.channel
-            where booslack.channel.id in (
-                select channelId from booslack.channel_users_user
-                where userId = ${userId})
+      select * from booslack.channel
+      where booslack.channel.id in (
+        select channelId from booslack.channel_user_has_workspaces_user_has_workspace
+        where booslack.channel_user_has_workspaces_user_has_workspace.userHasWorkspaceId = (
+          select id from booslack.user_has_workspace
+          where booslack.user_has_workspace.userId = ${userId}
+          and booslack.user_has_workspace.workspaceId = ${workspaceId}));
     `,
     );
   }

--- a/backend/src/repository/UserHasWorkspace.ts
+++ b/backend/src/repository/UserHasWorkspace.ts
@@ -1,0 +1,5 @@
+import { EntityRepository, Repository } from 'typeorm';
+import { UserHasWorkspace } from '../model/UserHasWorkspace';
+
+@EntityRepository(UserHasWorkspace)
+export default class UserHasWorkspaceRepository extends Repository<UserHasWorkspace> {}

--- a/backend/src/routes/ChannelController.ts
+++ b/backend/src/routes/ChannelController.ts
@@ -12,13 +12,14 @@ import {
 
 const channelRouter = Router();
 
+channelRouter.post('/userToChannel', addUserToChannel);
+channelRouter.delete('/userFromChannel', deleteUserFromChannel);
+channelRouter.get('/channelsThatUserIn', getChannelsThatUserIn);
+
 channelRouter.get('/', getAllChannels);
 channelRouter.get('/:id', getOneChannel);
 channelRouter.post('/', addOneChannel);
 channelRouter.put('/:id', updateOneChannel);
 channelRouter.delete('/:id', deleteOneChannel);
-channelRouter.post('/userToChannel', addUserToChannel);
-channelRouter.delete('/userFromChannel', deleteUserFromChannel);
-channelRouter.get('/channelsThatUserIn', getChannelsThatUserIn);
 
 export default channelRouter;

--- a/backend/src/routes/ChannelController.ts
+++ b/backend/src/routes/ChannelController.ts
@@ -7,6 +7,7 @@ import {
   deleteOneChannel,
   addUserToChannel,
   deleteUserFromChannel,
+  getChannelsThatUserIn,
 } from '../service/ChannelService';
 
 const channelRouter = Router();
@@ -18,5 +19,6 @@ channelRouter.put('/update/:id', updateOneChannel);
 channelRouter.delete('/delete/:id', deleteOneChannel);
 channelRouter.post('/addUserToChannel', addUserToChannel);
 channelRouter.post('/deleteUserFromChannel', deleteUserFromChannel);
+channelRouter.get('/getChannelsThatUserIn', getChannelsThatUserIn);
 
 export default channelRouter;

--- a/backend/src/routes/ChannelController.ts
+++ b/backend/src/routes/ChannelController.ts
@@ -12,13 +12,13 @@ import {
 
 const channelRouter = Router();
 
-channelRouter.get('/all', getAllChannels);
-channelRouter.get('/one/:id', getOneChannel);
-channelRouter.post('/add', addOneChannel);
-channelRouter.put('/update/:id', updateOneChannel);
-channelRouter.delete('/delete/:id', deleteOneChannel);
-channelRouter.post('/addUserToChannel', addUserToChannel);
-channelRouter.post('/deleteUserFromChannel', deleteUserFromChannel);
-channelRouter.get('/getChannelsThatUserIn', getChannelsThatUserIn);
+channelRouter.get('/', getAllChannels);
+channelRouter.get('/:id', getOneChannel);
+channelRouter.post('/', addOneChannel);
+channelRouter.put('/:id', updateOneChannel);
+channelRouter.delete('/:id', deleteOneChannel);
+channelRouter.post('/userToChannel', addUserToChannel);
+channelRouter.delete('/userFromChannel', deleteUserFromChannel);
+channelRouter.get('/channelsThatUserIn', getChannelsThatUserIn);
 
 export default channelRouter;

--- a/backend/src/routes/ChannelController.ts
+++ b/backend/src/routes/ChannelController.ts
@@ -5,6 +5,8 @@ import {
   addOneChannel,
   updateOneChannel,
   deleteOneChannel,
+  addUserToChannel,
+  deleteUserFromChannel,
 } from '../service/ChannelService';
 
 const channelRouter = Router();
@@ -14,5 +16,7 @@ channelRouter.get('/one/:id', getOneChannel);
 channelRouter.post('/add', addOneChannel);
 channelRouter.put('/update/:id', updateOneChannel);
 channelRouter.delete('/delete/:id', deleteOneChannel);
+channelRouter.post('/addUserToChannel', addUserToChannel);
+channelRouter.post('/deleteUserFromChannel', deleteUserFromChannel);
 
 export default channelRouter;

--- a/backend/src/service/ChannelService.ts
+++ b/backend/src/service/ChannelService.ts
@@ -129,3 +129,15 @@ export async function deleteUserFromChannel(req: Request, res: Response) {
     return res.status(BAD_REQUEST).json(e);
   }
 }
+
+export async function getChannelsThatUserIn(req: Request, res: Response) {
+  try {
+    const userId = req.query.userId as string;
+    const channels = await getCustomRepository(
+      ChannelRepository,
+    ).findChannelsThatUserIn(userId);
+    return res.status(OK).json({ channels });
+  } catch (e) {
+    return res.status(BAD_REQUEST).json(e);
+  }
+}

--- a/backend/src/service/UserService.ts
+++ b/backend/src/service/UserService.ts
@@ -27,8 +27,10 @@ export async function getOneUser(req: Request, res: Response) {
 export async function updateOneUser(req: Request, res: Response) {
   const { id } = req.params;
   const { nickname, email, type } = req.body;
+
   try {
-    if (Object.keys(req.body).length === 0) throw new Error('no user data in body');
+    if (Object.keys(req.body).length === 0)
+      throw new Error('no user data in body');
     const userById = await getRepository(User).findOneOrFail(id);
     userById.nickname = nickname || userById.nickname;
     userById.email = email || userById.email;

--- a/backend/src/service/WorkspaceService.ts
+++ b/backend/src/service/WorkspaceService.ts
@@ -24,7 +24,7 @@ export async function getOneWorkspace(req: Request, res: Response) {
 }
 
 export async function addOneWorkspace(req: Request, res: Response) {
-  const { workspace } = req.body;
+  const workspace = req.body;
   if (!workspace) {
     return res.status(BAD_REQUEST).json({
       error: paramMissingError,
@@ -38,7 +38,8 @@ export async function updateOneWorkspace(req: Request, res: Response) {
   const { id } = req.params;
   const { profile, name } = req.body;
   try {
-    if (Object.keys(req.body).length === 0) throw new Error('no workspace data in body');
+    if (Object.keys(req.body).length === 0)
+      throw new Error('no workspace data in body');
     const workspaceById = await getCustomRepository(
       WorkspaceRepository,
     ).findOneOrFail(id);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,7 +14,7 @@ const App = (): JSX.Element => {
         <Route path="/login">
           <Login />
         </Route>
-        <Route path="/workspace">
+        <Route exact path="/client/:channelName">
           <Workspace />
         </Route>
         <Route path="/signup">

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,7 +14,7 @@ const App = (): JSX.Element => {
         <Route path="/login">
           <Login />
         </Route>
-        <Route exact path="/client/:channelName">
+        <Route exact path="/client/:channelId">
           <Workspace />
         </Route>
         <Route path="/signup">

--- a/frontend/src/components/molecules/SidebarChannelElement/index.tsx
+++ b/frontend/src/components/molecules/SidebarChannelElement/index.tsx
@@ -6,15 +6,17 @@ interface Props {
   onClick: () => void;
   label: string;
   isPrivate: boolean;
+  onContextMenu: (e) => void;
 }
 
 const SidebarChannelElement = ({
   onClick,
   label,
   isPrivate,
+  onContextMenu,
 }: Props): JSX.Element => {
   return (
-    <Container onClick={onClick}>
+    <Container onClick={onClick} onContextMenu={onContextMenu}>
       <StyledLabel>
         <Label text={isPrivate ? '🔒' : '#'} />
       </StyledLabel>

--- a/frontend/src/components/organisms/ChannelJoinFooter/index.tsx
+++ b/frontend/src/components/organisms/ChannelJoinFooter/index.tsx
@@ -10,9 +10,10 @@ interface Props {
 }
 
 const addUserToChannel = async (id: string) => {
-  await axios.post('http://localhost:8081/api/channel/addUserToChannel', {
+  await axios.post('http://localhost:8081/api/channel/userToChannel', {
     userId: sessionStorage.getItem('id'),
     channelId: id,
+    workspaceId: sessionStorage.getItem('workspaceId'),
   });
   window.location.href = window.location.href;
 };

--- a/frontend/src/components/organisms/ChannelJoinFooter/index.tsx
+++ b/frontend/src/components/organisms/ChannelJoinFooter/index.tsx
@@ -1,0 +1,44 @@
+import { ChatInputSize } from '@enum/index';
+import React, { useMemo } from 'react';
+import { Container } from './styles';
+import LabeledButton from '@atoms/LabeledButton';
+import axios from 'axios';
+
+interface Props {
+  channelName: string;
+  channelId: number;
+}
+
+const addUserToChannel = async (id: string) => {
+  await axios.post('http://localhost:8081/api/channel/addUserToChannel', {
+    userId: sessionStorage.getItem('id'),
+    channelId: id,
+  });
+  window.location.href = window.location.href;
+};
+
+const ChatInputBackGround = ({
+  channelId,
+  channelName,
+}: Props): JSX.Element => {
+  const { width, height } = useMemo(() => {
+    return ChatInputSize;
+  }, []);
+
+  return (
+    <Container width={width} height={height}>
+      <div>#{channelName}을(를) 보고 있습니다.</div>
+      <div>
+        <LabeledButton
+          onClick={() => {
+            addUserToChannel(String(channelId));
+          }}
+          text="채널 참여"
+        />
+        <LabeledButton onClick={() => {}} text="추가 정보 보기" />
+      </div>
+    </Container>
+  );
+};
+
+export default ChatInputBackGround;

--- a/frontend/src/components/organisms/ChannelJoinFooter/styles.ts
+++ b/frontend/src/components/organisms/ChannelJoinFooter/styles.ts
@@ -1,0 +1,19 @@
+import styled from 'styled-components';
+
+interface Props {
+  width: number;
+  height: number;
+}
+
+export const Container = styled.div<Props>`
+  display: flex;
+  flex-direction: column;
+  width: inherit;
+  height: 10vh;
+
+  align-items: center;
+  border: 0;
+  background-color: pink;
+`;
+
+export default Container;

--- a/frontend/src/components/organisms/SidebarChannelInfoModal/index.tsx
+++ b/frontend/src/components/organisms/SidebarChannelInfoModal/index.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import LabeledButton from '@atoms/LabeledButton';
+import Modal from '@atoms/Modal';
+import { useRecoilState } from 'recoil';
+import { sidebarChannelInfoModalState } from 'src/state/modal';
+import axios from 'axios';
+import { Container } from './styles';
+
+const SidebarChannelInfoModal = (): JSX.Element => {
+  const [isOpen, setIsOpen] = useRecoilState(sidebarChannelInfoModalState);
+
+  const exitChannel = async () => {
+    // await axios({
+    //   method: 'POST',
+    //   url: 'api/channel/deleteUserFromChannel',
+    //   data: {
+    //     userId: sessionStorage.getItem('id'),
+    //     channelId: '채널이름',
+    //   },
+    // });
+    setIsOpen(false);
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={() => setIsOpen(false)}>
+      <Container>
+        <LabeledButton text="분할 화면으로 열기" onClick={() => {}} />
+        <div>
+          <hr />
+        </div>
+        <LabeledButton text="알림 변경" onClick={() => {}} />
+        <LabeledButton text="채널 음소거" onClick={() => {}} />
+        <div>
+          <hr />
+        </div>
+        <LabeledButton text="이름 복사" onClick={() => {}} />
+        <LabeledButton text="링크 복사" onClick={() => {}} />
+        <div>
+          <hr />
+        </div>
+        <LabeledButton text="채널을 즐겨찾기에추가" onClick={() => {}} />
+        <LabeledButton text="새 섹션으로 이동" onClick={() => {}} />
+        <div>
+          <hr />
+        </div>
+        <LabeledButton text="채널 세부정보 열기" onClick={() => {}} />
+        <LabeledButton text="채널에서 나가기" onClick={exitChannel} />
+        <div>
+          <hr />
+        </div>
+        <LabeledButton text="새 섹션 생성" onClick={() => {}} />
+        <LabeledButton text="사이드바 편집" onClick={() => {}} />
+      </Container>
+    </Modal>
+  );
+};
+
+export default SidebarChannelInfoModal;

--- a/frontend/src/components/organisms/SidebarChannelInfoModal/styles.ts
+++ b/frontend/src/components/organisms/SidebarChannelInfoModal/styles.ts
@@ -1,0 +1,13 @@
+import styled from 'styled-components';
+
+interface Props {
+  width: number;
+  height: number;
+}
+
+export const Container = styled.div<Props>`
+  display: flex;
+  flex-direction: column;
+  border-radius: 16px;
+  padding: 12px 24px;
+`;

--- a/frontend/src/components/organisms/WorkspaceContent/index.tsx
+++ b/frontend/src/components/organisms/WorkspaceContent/index.tsx
@@ -3,13 +3,47 @@ import LabeledDefaultButton from '@atoms/LabeledDefaultButton';
 import ChatHeader from '@molecules/ChatHeader';
 import ChatInputBackground from '@organisms/ChatInputBackground';
 import ChatContent from '@organisms/ChatContent';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Container, MarginedDiv } from './style';
 import { useParams } from 'react-router-dom';
+import { channelListFromServerState } from 'src/state/Channel';
+import { useRecoilValue } from 'recoil';
+import ChannelJoinFooter from '@organisms/ChannelJoinFooter';
+import axios from 'axios';
+
+const getChannelById = (id: string) => {
+  const [channel, setChannel] = useState();
+  useEffect(() => {
+    (async () => {
+      const response = await axios.get(
+        `http://localhost:8081/api/channel/one/${id}`,
+      );
+      setChannel(response.data.channel);
+    })();
+  }, [id]);
+
+  return { channel /* loading, error */ };
+};
 
 const WorkspaceContent = (): JSX.Element => {
-  const { channelName } = useParams();
-  const ChannelTitle: JSX.Element = <Label text={`# ${channelName}`} />;
+  const { channelId } = useParams();
+
+  const channelList = useRecoilValue(
+    channelListFromServerState(sessionStorage.getItem('id')),
+  );
+  const isUserInCurrentChannel = channelList.channels.find(
+    (channel) => String(channel.id) === channelId,
+  );
+
+  const currentChannel = getChannelById(channelId);
+  const channelTitleText = currentChannel.channel
+    ? currentChannel.channel.name
+    : '로딩';
+  const channelIdText = currentChannel.channel
+    ? currentChannel.channel.id
+    : '로딩';
+
+  const ChannelTitle: JSX.Element = <Label text={`# ${channelTitleText}`} />;
   const ExplainContent: JSX.Element | null = (
     <Label color="grey" text="channel explain " />
   );
@@ -20,8 +54,25 @@ const WorkspaceContent = (): JSX.Element => {
       {ExplainContent}
     </MarginedDiv>
   );
-  const InputBar: JSX.Element = <ChatInputBackground />;
-  const RightButton = <LabeledDefaultButton onClick={() => {}} text="button" />;
+
+  const InputBar: JSX.Element = isUserInCurrentChannel ? (
+    <ChatInputBackground />
+  ) : (
+    <ChannelJoinFooter
+      channelId={channelIdText}
+      channelName={channelTitleText}
+    />
+  );
+  const RightButton = (
+    <LabeledButton
+      onClick={() => {}}
+      width={30}
+      height={30}
+      color={'black'}
+      backgroundColor={'white'}
+    />
+  );
+
   return (
     <Container>
       <ChatHeader title={Title} content={null} rightButton={RightButton} />

--- a/frontend/src/components/organisms/WorkspaceContent/index.tsx
+++ b/frontend/src/components/organisms/WorkspaceContent/index.tsx
@@ -16,7 +16,7 @@ const getChannelById = (id: string) => {
   useEffect(() => {
     (async () => {
       const response = await axios.get(
-        `http://localhost:8081/api/channel/one/${id}`,
+        `http://localhost:8081/api/channel/${id}`,
       );
       setChannel(response.data.channel);
     })();
@@ -29,7 +29,10 @@ const WorkspaceContent = (): JSX.Element => {
   const { channelId } = useParams();
 
   const channelList = useRecoilValue(
-    channelListFromServerState(sessionStorage.getItem('id')),
+    channelListFromServerState({
+      userId: sessionStorage.getItem('id'),
+      workspaceId: sessionStorage.getItem('workspaceId'),
+    }),
   );
   const isUserInCurrentChannel = channelList.channels.find(
     (channel) => String(channel.id) === channelId,

--- a/frontend/src/components/organisms/WorkspaceContent/index.tsx
+++ b/frontend/src/components/organisms/WorkspaceContent/index.tsx
@@ -5,9 +5,11 @@ import ChatInputBackground from '@organisms/ChatInputBackground';
 import ChatContent from '@organisms/ChatContent';
 import React from 'react';
 import { Container, MarginedDiv } from './style';
+import { useParams } from 'react-router-dom';
 
 const WorkspaceContent = (): JSX.Element => {
-  const ChannelTitle: JSX.Element = <Label text="# channel name" />;
+  const { channelName } = useParams();
+  const ChannelTitle: JSX.Element = <Label text={`# ${channelName}`} />;
   const ExplainContent: JSX.Element | null = (
     <Label color="grey" text="channel explain " />
   );

--- a/frontend/src/components/organisms/WorkspaceContent/index.tsx
+++ b/frontend/src/components/organisms/WorkspaceContent/index.tsx
@@ -67,7 +67,8 @@ const WorkspaceContent = (): JSX.Element => {
     />
   );
   const RightButton = (
-    <LabeledButton
+    <LabeledDefaultButton
+      text="무야호"
       onClick={() => {}}
       width={30}
       height={30}

--- a/frontend/src/components/organisms/WorkspaceSidebar/index.tsx
+++ b/frontend/src/components/organisms/WorkspaceSidebar/index.tsx
@@ -3,55 +3,60 @@ import SidebarChannelElement from '@molecules/SidebarChannelElement';
 import React from 'react';
 import { Container } from './style';
 import SidebarAddElement from '@molecules/SidebarAddElement';
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import {
   channelCreateModalState,
   sidebarChannelInfoModalState,
 } from 'src/state/modal';
-import { BrowserRouter, NavLink } from 'react-router-dom';
+import { NavLink } from 'react-router-dom';
+import { channelListFromServerState } from 'src/state/Channel';
 
 const WorkspaceSidebar = (): JSX.Element => {
   const [isChannelCreateModalOpen, setIsChannelCreateModalOpen] =
     useRecoilState(channelCreateModalState);
   const [isSidebarChannelInfoModalOpen, setIsSidebarChannelInfoModalOpen] =
     useRecoilState(sidebarChannelInfoModalState);
+  const channelList = useRecoilValue(
+    channelListFromServerState(sessionStorage.getItem('id')),
+  );
 
   return (
     <Container>
       <SidebarDivision label="Channels" options={true} type="Channels" />
       <NavLink
-        to="/client/random"
+        to="/client/browse-channels"
         style={{ textDecoration: 'none', color: 'black' }}
         activeStyle={{ color: 'red' }}
       >
         <SidebarChannelElement
-          label="random"
+          label="browse-channels"
           isPrivate={false}
           onClick={() => {}}
           onContextMenu={(e) => {
             e.preventDefault();
-            setIsSidebarChannelInfoModalOpen(true);
           }}
         />
       </NavLink>
-      <NavLink
-        to={(location) => ({
-          ...location,
-          pathname: '/client/private-channel',
-        })}
-        style={{ textDecoration: 'none', color: 'black' }}
-        activeStyle={{ color: 'red' }}
-      >
-        <SidebarChannelElement
-          label="private channel"
-          isPrivate={true}
-          onClick={() => {}}
-          onContextMenu={(e) => {
-            e.preventDefault();
-            setIsSidebarChannelInfoModalOpen(true);
-          }}
-        />
-      </NavLink>
+
+      {channelList.channels.map((channel) => {
+        return (
+          <NavLink
+            to={`/client/${channel.name}`}
+            style={{ textDecoration: 'none', color: 'black' }}
+            activeStyle={{ color: 'red' }}
+          >
+            <SidebarChannelElement
+              label={channel.name}
+              isPrivate={channel.type === 'private'}
+              onClick={() => {}}
+              onContextMenu={(e) => {
+                e.preventDefault();
+                setIsSidebarChannelInfoModalOpen(true);
+              }}
+            />
+          </NavLink>
+        );
+      })}
       <SidebarAddElement
         label="Add Channels"
         onClick={() => setIsChannelCreateModalOpen(true)}

--- a/frontend/src/components/organisms/WorkspaceSidebar/index.tsx
+++ b/frontend/src/components/organisms/WorkspaceSidebar/index.tsx
@@ -8,6 +8,7 @@ import {
   channelCreateModalState,
   sidebarChannelInfoModalState,
 } from 'src/state/modal';
+import { BrowserRouter, Link } from 'react-router-dom';
 
 const WorkspaceSidebar = (): JSX.Element => {
   const [isChannelCreateModalOpen, setIsChannelCreateModalOpen] =
@@ -16,31 +17,43 @@ const WorkspaceSidebar = (): JSX.Element => {
     useRecoilState(sidebarChannelInfoModalState);
 
   return (
-    <Container>
-      <SidebarDivision label="Channels" options={true} type="Channels" />
-      <SidebarChannelElement
-        label="random"
-        isPrivate={false}
-        onClick={() => {}}
-        onContextMenu={(e) => {
-          e.preventDefault();
-          setIsSidebarChannelInfoModalOpen(true);
-        }}
-      />
-      <SidebarChannelElement
-        label="private channel"
-        isPrivate={true}
-        onClick={() => {}}
-        onContextMenu={(e) => {
-          e.preventDefault();
-          setIsSidebarChannelInfoModalOpen(true);
-        }}
-      />
-      <SidebarAddElement
-        label="Add Channels"
-        onClick={() => setIsChannelCreateModalOpen(true)}
-      />
-    </Container>
+    <BrowserRouter>
+      <Container>
+        <SidebarDivision label="Channels" options={true} type="Channels" />
+        <Link
+          to={`${window.location.pathname}/random`}
+          style={{ textDecoration: 'none', color: 'black' }}
+        >
+          <SidebarChannelElement
+            label="random"
+            isPrivate={false}
+            onClick={() => {}}
+            onContextMenu={(e) => {
+              e.preventDefault();
+              setIsSidebarChannelInfoModalOpen(true);
+            }}
+          />
+        </Link>
+        <Link
+          to={`${window.location.pathname}/privateChannel`}
+          style={{ textDecoration: 'none', color: 'black' }}
+        >
+          <SidebarChannelElement
+            label="private channel"
+            isPrivate={true}
+            onClick={() => {}}
+            onContextMenu={(e) => {
+              e.preventDefault();
+              setIsSidebarChannelInfoModalOpen(true);
+            }}
+          />
+        </Link>
+        <SidebarAddElement
+          label="Add Channels"
+          onClick={() => setIsChannelCreateModalOpen(true)}
+        />
+      </Container>
+    </BrowserRouter>
   );
 };
 

--- a/frontend/src/components/organisms/WorkspaceSidebar/index.tsx
+++ b/frontend/src/components/organisms/WorkspaceSidebar/index.tsx
@@ -17,7 +17,10 @@ const WorkspaceSidebar = (): JSX.Element => {
   const [isSidebarChannelInfoModalOpen, setIsSidebarChannelInfoModalOpen] =
     useRecoilState(sidebarChannelInfoModalState);
   const channelList = useRecoilValue(
-    channelListFromServerState(sessionStorage.getItem('id')),
+    channelListFromServerState({
+      userId: sessionStorage.getItem('id'),
+      workspaceId: sessionStorage.getItem('workspaceId'),
+    }),
   );
 
   return (

--- a/frontend/src/components/organisms/WorkspaceSidebar/index.tsx
+++ b/frontend/src/components/organisms/WorkspaceSidebar/index.tsx
@@ -8,7 +8,7 @@ import {
   channelCreateModalState,
   sidebarChannelInfoModalState,
 } from 'src/state/modal';
-import { BrowserRouter, Link } from 'react-router-dom';
+import { BrowserRouter, NavLink } from 'react-router-dom';
 
 const WorkspaceSidebar = (): JSX.Element => {
   const [isChannelCreateModalOpen, setIsChannelCreateModalOpen] =
@@ -17,43 +17,46 @@ const WorkspaceSidebar = (): JSX.Element => {
     useRecoilState(sidebarChannelInfoModalState);
 
   return (
-    <BrowserRouter>
-      <Container>
-        <SidebarDivision label="Channels" options={true} type="Channels" />
-        <Link
-          to={`${window.location.pathname}/random`}
-          style={{ textDecoration: 'none', color: 'black' }}
-        >
-          <SidebarChannelElement
-            label="random"
-            isPrivate={false}
-            onClick={() => {}}
-            onContextMenu={(e) => {
-              e.preventDefault();
-              setIsSidebarChannelInfoModalOpen(true);
-            }}
-          />
-        </Link>
-        <Link
-          to={`${window.location.pathname}/privateChannel`}
-          style={{ textDecoration: 'none', color: 'black' }}
-        >
-          <SidebarChannelElement
-            label="private channel"
-            isPrivate={true}
-            onClick={() => {}}
-            onContextMenu={(e) => {
-              e.preventDefault();
-              setIsSidebarChannelInfoModalOpen(true);
-            }}
-          />
-        </Link>
-        <SidebarAddElement
-          label="Add Channels"
-          onClick={() => setIsChannelCreateModalOpen(true)}
+    <Container>
+      <SidebarDivision label="Channels" options={true} type="Channels" />
+      <NavLink
+        to="/client/random"
+        style={{ textDecoration: 'none', color: 'black' }}
+        activeStyle={{ color: 'red' }}
+      >
+        <SidebarChannelElement
+          label="random"
+          isPrivate={false}
+          onClick={() => {}}
+          onContextMenu={(e) => {
+            e.preventDefault();
+            setIsSidebarChannelInfoModalOpen(true);
+          }}
         />
-      </Container>
-    </BrowserRouter>
+      </NavLink>
+      <NavLink
+        to={(location) => ({
+          ...location,
+          pathname: '/client/private-channel',
+        })}
+        style={{ textDecoration: 'none', color: 'black' }}
+        activeStyle={{ color: 'red' }}
+      >
+        <SidebarChannelElement
+          label="private channel"
+          isPrivate={true}
+          onClick={() => {}}
+          onContextMenu={(e) => {
+            e.preventDefault();
+            setIsSidebarChannelInfoModalOpen(true);
+          }}
+        />
+      </NavLink>
+      <SidebarAddElement
+        label="Add Channels"
+        onClick={() => setIsChannelCreateModalOpen(true)}
+      />
+    </Container>
   );
 };
 

--- a/frontend/src/components/organisms/WorkspaceSidebar/index.tsx
+++ b/frontend/src/components/organisms/WorkspaceSidebar/index.tsx
@@ -41,7 +41,7 @@ const WorkspaceSidebar = (): JSX.Element => {
       {channelList.channels.map((channel) => {
         return (
           <NavLink
-            to={`/client/${channel.name}`}
+            to={`/client/${channel.id}`}
             style={{ textDecoration: 'none', color: 'black' }}
             activeStyle={{ color: 'red' }}
           >

--- a/frontend/src/components/organisms/WorkspaceSidebar/index.tsx
+++ b/frontend/src/components/organisms/WorkspaceSidebar/index.tsx
@@ -4,10 +4,16 @@ import React from 'react';
 import { Container } from './style';
 import SidebarAddElement from '@molecules/SidebarAddElement';
 import { useRecoilState } from 'recoil';
-import { channelCreateModalState } from 'src/state/modal';
+import {
+  channelCreateModalState,
+  sidebarChannelInfoModalState,
+} from 'src/state/modal';
 
 const WorkspaceSidebar = (): JSX.Element => {
-  const [isOpen, setIsOpen] = useRecoilState(channelCreateModalState);
+  const [isChannelCreateModalOpen, setIsChannelCreateModalOpen] =
+    useRecoilState(channelCreateModalState);
+  const [isSidebarChannelInfoModalOpen, setIsSidebarChannelInfoModalOpen] =
+    useRecoilState(sidebarChannelInfoModalState);
 
   return (
     <Container>
@@ -16,13 +22,24 @@ const WorkspaceSidebar = (): JSX.Element => {
         label="random"
         isPrivate={false}
         onClick={() => {}}
+        onContextMenu={(e) => {
+          e.preventDefault();
+          setIsSidebarChannelInfoModalOpen(true);
+        }}
       />
       <SidebarChannelElement
         label="private channel"
         isPrivate={true}
         onClick={() => {}}
+        onContextMenu={(e) => {
+          e.preventDefault();
+          setIsSidebarChannelInfoModalOpen(true);
+        }}
       />
-      <SidebarAddElement label="Add Channels" onClick={() => setIsOpen(true)} />
+      <SidebarAddElement
+        label="Add Channels"
+        onClick={() => setIsChannelCreateModalOpen(true)}
+      />
     </Container>
   );
 };

--- a/frontend/src/components/pages/Workspace/index.tsx
+++ b/frontend/src/components/pages/Workspace/index.tsx
@@ -12,9 +12,7 @@ const Workspace = (): JSX.Element => {
     channelId === 'browse-channels' ? <BrowseContent /> : <WorkspaceContent />;
   return (
     <>
-      <Suspense fallback={() => <p>Loading...</p>}>
-        <WorkspaceTemplate Content={workspaceContent}></WorkspaceTemplate>
-      </Suspense>
+      <WorkspaceTemplate Content={workspaceContent}></WorkspaceTemplate>
       <CreateChannelModal />
       <SidebarChannelInfoModal />
     </>

--- a/frontend/src/components/pages/Workspace/index.tsx
+++ b/frontend/src/components/pages/Workspace/index.tsx
@@ -3,13 +3,20 @@ import WorkspaceTemplate from '@templates/Workspace';
 import WorkspaceContent from '@organisms/WorkspaceContent';
 import CreateChannelModal from '@organisms/CreateChannelModal';
 import SidebarChannelInfoModal from '@organisms/SidebarChannelInfoModal';
+import { useParams } from 'react-router-dom';
+import BrowseContent from '@organisms/BrowseContent';
 
 const Workspace = (): JSX.Element => {
-  const ChatContent: JSX.Element = <WorkspaceContent />;
-
+  const { channelName } = useParams();
+  const workspaceContent =
+    channelName === 'browse-channels' ? (
+      <BrowseContent />
+    ) : (
+      <WorkspaceContent />
+    );
   return (
     <>
-      <WorkspaceTemplate Content={ChatContent} />
+      <WorkspaceTemplate Content={workspaceContent}></WorkspaceTemplate>
       <CreateChannelModal />
       <SidebarChannelInfoModal />
     </>

--- a/frontend/src/components/pages/Workspace/index.tsx
+++ b/frontend/src/components/pages/Workspace/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import WorkspaceTemplate from '@templates/Workspace';
 import WorkspaceContent from '@organisms/WorkspaceContent';
 import CreateChannelModal from '@organisms/CreateChannelModal';
+import SidebarChannelInfoModal from '@organisms/SidebarChannelInfoModal';
 
 const Workspace = (): JSX.Element => {
   const ChatContent: JSX.Element = <WorkspaceContent />;
@@ -10,6 +11,7 @@ const Workspace = (): JSX.Element => {
     <>
       <WorkspaceTemplate Content={ChatContent} />
       <CreateChannelModal />
+      <SidebarChannelInfoModal />
     </>
   );
 };

--- a/frontend/src/components/pages/Workspace/index.tsx
+++ b/frontend/src/components/pages/Workspace/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 import WorkspaceTemplate from '@templates/Workspace';
 import WorkspaceContent from '@organisms/WorkspaceContent';
 import CreateChannelModal from '@organisms/CreateChannelModal';
@@ -7,16 +7,14 @@ import { useParams } from 'react-router-dom';
 import BrowseContent from '@organisms/BrowseContent';
 
 const Workspace = (): JSX.Element => {
-  const { channelName } = useParams();
+  const { channelId } = useParams();
   const workspaceContent =
-    channelName === 'browse-channels' ? (
-      <BrowseContent />
-    ) : (
-      <WorkspaceContent />
-    );
+    channelId === 'browse-channels' ? <BrowseContent /> : <WorkspaceContent />;
   return (
     <>
-      <WorkspaceTemplate Content={workspaceContent}></WorkspaceTemplate>
+      <Suspense fallback={() => <p>Loading...</p>}>
+        <WorkspaceTemplate Content={workspaceContent}></WorkspaceTemplate>
+      </Suspense>
       <CreateChannelModal />
       <SidebarChannelInfoModal />
     </>

--- a/frontend/src/components/templates/Workspace/index.tsx
+++ b/frontend/src/components/templates/Workspace/index.tsx
@@ -9,13 +9,13 @@ interface Props {
 
 const WorkspaceTemplate = ({ Content }: Props): JSX.Element => {
   return (
-    <>
+    <Suspense fallback={() => <p>Loading...</p>}>
       <WorkspaceHeader />
       <RowDiv>
         <WorkspaceSidebar />
         {Content}
       </RowDiv>
-    </>
+    </Suspense>
   );
 };
 

--- a/frontend/src/components/templates/Workspace/index.tsx
+++ b/frontend/src/components/templates/Workspace/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 import WorkspaceHeader from '@organisms/WorkspaceHeader';
 import WorkspaceSidebar from '@organisms/WorkspaceSidebar';
 import { RowDiv } from './styles';
@@ -12,7 +12,9 @@ const WorkspaceTemplate = ({ Content }: Props): JSX.Element => {
     <>
       <WorkspaceHeader />
       <RowDiv>
-        <WorkspaceSidebar />
+        <Suspense fallback={() => <p>Loading...</p>}>
+          <WorkspaceSidebar />
+        </Suspense>
         {Content}
       </RowDiv>
     </>

--- a/frontend/src/components/templates/Workspace/index.tsx
+++ b/frontend/src/components/templates/Workspace/index.tsx
@@ -12,9 +12,7 @@ const WorkspaceTemplate = ({ Content }: Props): JSX.Element => {
     <>
       <WorkspaceHeader />
       <RowDiv>
-        <Suspense fallback={() => <p>Loading...</p>}>
-          <WorkspaceSidebar />
-        </Suspense>
+        <WorkspaceSidebar />
         {Content}
       </RowDiv>
     </>

--- a/frontend/src/global/api/index.ts
+++ b/frontend/src/global/api/index.ts
@@ -1,7 +1,7 @@
 export const API = {
   get: {
     channel: {
-      all: '/api/channel/all',
+      all: '/api/channel/',
     },
   },
 } as const;

--- a/frontend/src/state/Channel/index.ts
+++ b/frontend/src/state/Channel/index.ts
@@ -25,11 +25,9 @@ export const browseCursorValue = selector<number>({
 
 export const channelListFromServerState = selectorFamily({
   key: 'channelListFromServer',
-  get: (userId) => async () => {
+  get: (data) => async () => {
     const response = await axios.get(
-      `http://localhost:8081/api/channel/getChannelsThatUserIn?userId=${String(
-        userId,
-      )}`,
+      `http://localhost:8081/api/channel/channelsThatUserIn?userId=${data.userId}&workspaceId=${data.workspaceId}`,
     );
     return response.data;
   },

--- a/frontend/src/state/Channel/index.ts
+++ b/frontend/src/state/Channel/index.ts
@@ -1,6 +1,7 @@
 import { pageLimitCount } from '@enum/index';
 import { SortOption } from '@global/type';
-import { atom, selector } from 'recoil';
+import { atom, selector, selectorFamily } from 'recoil';
+import axios from 'axios';
 
 export const channelListState = atom({
   key: 'ChannelList',
@@ -20,4 +21,16 @@ export const browseCursor = atom<number>({
 export const browseCursorValue = selector<number>({
   key: 'browseCursorValue',
   get: ({ get }) => (get(browseCursor) - 1) * pageLimitCount,
+});
+
+export const channelListFromServerState = selectorFamily({
+  key: 'channelListFromServer',
+  get: (userId) => async () => {
+    const response = await axios.get(
+      `http://localhost:8081/api/channel/getChannelsThatUserIn?userId=${String(
+        userId,
+      )}`,
+    );
+    return response.data;
+  },
 });

--- a/frontend/src/state/modal/index.tsx
+++ b/frontend/src/state/modal/index.tsx
@@ -4,3 +4,8 @@ export const channelCreateModalState = atom({
   key: 'createChannel',
   default: false,
 });
+
+export const sidebarChannelInfoModalState = atom({
+  key: 'sidebarChannelModal',
+  default: false,
+});

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -31,6 +31,7 @@ module.exports = {
   output: {
     path: path.join(__dirname, 'dist'),
     clean: true,
+    publicPath: '/',
   },
   module: {
     rules: [


### PR DESCRIPTION
## 📃 PR 제목
채널에 대한 라우팅과 채널 참가하기 구현

## 📃 작업 목록
1.채널에 들어가고 나갈 수 있는 API 작성
2.채널 나가기를 위한 모달 작성
3.채널 이름에 따른 라우팅 구현
4.사이드바에서 채널을 선택하면 라우팅이 되고 페이지가 로딩됨.
5.유저가 들어있는 채널들을 가져오는 api 생성
6.미 참여중에 채널을 참가할 수 있도록 구현

## 📃 주의 사항

## 📃 추가 메모 사항
DB의 erd가 변경되어 그에 맞게 수정하였습니다.