### PR TITLE
feat: react-query로 리팩토링과 recoil & useParams로 현재 상태 저장

### DIFF
--- a/backend/src/@types/express/index.d.ts
+++ b/backend/src/@types/express/index.d.ts
@@ -18,6 +18,8 @@ declare module 'express' {
       message: string;
       time: Date;
       code: string;
+      theme: string;
+      fileId: string;
 
       userId: string;
       channelId: string;

--- a/backend/src/routes/UserHasWorkspaceController.ts
+++ b/backend/src/routes/UserHasWorkspaceController.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { getUserHasWorkspace, updateUserHasWorkspace } from '@service/UserHasWorkspaceService';
+
+const userHasWorkspaceRouter = Router();
+
+userHasWorkspaceRouter.get('/', getUserHasWorkspace);
+userHasWorkspaceRouter.put('/:id', updateUserHasWorkspace);
+
+export default userHasWorkspaceRouter;

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -4,9 +4,11 @@ import userRouter from './UserController';
 import workspaceRouter from './WorkspaceController';
 import loginRouter from './LoginController';
 import threadRouter from './ThreadController';
+import userHasWorkspaceRouter from './UserHasWorkspaceController';
 
 const baseRouter = Router();
 baseRouter.use('/users', userRouter);
+baseRouter.use('/userHasWorkspaces', userHasWorkspaceRouter);
 baseRouter.use('/workspaces', workspaceRouter);
 baseRouter.use('/channels', channelRouter);
 baseRouter.use('/threads', threadRouter);

--- a/backend/src/service/ChannelService.ts
+++ b/backend/src/service/ChannelService.ts
@@ -42,28 +42,32 @@ export async function getOneChannel(req: Request, res: Response) {
 }
 
 export async function addOneChannel(req: Request, res: Response) {
-  const channel = req.body;
-  if (!channel) {
-    return res.status(BAD_REQUEST).json({
-      error: paramMissingError,
+  try {
+    const channel = req.body;
+    if (!channel) {
+      return res.status(BAD_REQUEST).json({
+        error: paramMissingError,
+      });
+    }
+
+    const workspace = await getCustomRepository(WorkspaceRepository).findOne({
+      where: [{ id: channel.workspaceId }],
     });
+
+    if (!workspace) {
+      throw new Error(`workspace ${channel.workspaceId} does not exist`);
+    }
+
+    channel.workspace = workspace;
+    const ChannelRepo = getCustomRepository(ChannelRepository);
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    const newChannel = await ChannelRepo.save(ChannelRepo.create(channel));
+
+    return res.status(CREATED).json({ channel: newChannel });
+  } catch (e) {
+    return res.status(BAD_REQUEST).json(e);
   }
-
-  const workspace = await getCustomRepository(WorkspaceRepository).findOne({
-    where: [{ id: channel.workspaceId }],
-  });
-
-  if (!workspace) {
-    throw new Error(`workspace ${channel.workspaceId} does not exist`);
-  }
-
-  channel.workspace = workspace;
-  const ChannelRepo = getCustomRepository(ChannelRepository);
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  await ChannelRepo.save(ChannelRepo.create(channel));
-
-  return res.status(CREATED).end();
 }
 
 export async function updateOneChannel(req: Request, res: Response) {

--- a/backend/src/service/UserHasWorkspaceService.ts
+++ b/backend/src/service/UserHasWorkspaceService.ts
@@ -1,0 +1,50 @@
+import { StatusCodes } from 'http-status-codes';
+import { Request, Response } from 'express';
+import { getCustomRepository } from 'typeorm';
+import UserHasWorkspaceRepository from '../repository/UserHasWorkspaceRepository';
+
+const { BAD_REQUEST, OK } = StatusCodes;
+
+export async function getUserHasWorkspace(req: Request, res: Response) {
+  try {
+    const { userId, workspaceId } = req.query;
+
+    const userHasWorkspace = await getCustomRepository(UserHasWorkspaceRepository).findOne({
+      where: [{ userId, workspaceId }],
+    });
+
+    if (!userHasWorkspace) {
+      throw new Error(
+        `userHasWorkspace with user ${userId} and workspace ${workspaceId} does not exist`,
+      );
+    }
+
+    return res.status(OK).json({ userHasWorkspace });
+  } catch (e) {
+    return res.status(BAD_REQUEST).json(e);
+  }
+}
+
+export async function updateUserHasWorkspace(req: Request, res: Response) {
+  try {
+    const { userHasWorkspaceId } = req.params;
+    const { nickname, description, theme, fileId } = req.body;
+
+    const userHasWorkspaceById = await getCustomRepository(
+      UserHasWorkspaceRepository,
+    ).findOneOrFail(userHasWorkspaceId);
+
+    userHasWorkspaceById.nickname = nickname || userHasWorkspaceById.nickname;
+    userHasWorkspaceById.description = description || userHasWorkspaceById.description;
+    userHasWorkspaceById.theme = theme || userHasWorkspaceById.theme;
+    userHasWorkspaceById.fileId = fileId || userHasWorkspaceById.fileId;
+
+    const userHasWorkspace = await getCustomRepository(UserHasWorkspaceRepository).save(
+      userHasWorkspaceById,
+    );
+
+    return res.status(OK).json({ userHasWorkspace });
+  } catch (e) {
+    return res.status(BAD_REQUEST).json(e);
+  }
+}

--- a/frontend/src/components/atoms/LabeledButton/index.tsx
+++ b/frontend/src/components/atoms/LabeledButton/index.tsx
@@ -2,7 +2,7 @@ import React, { RefObject } from 'react';
 import Container from './styles';
 
 interface Props<T> {
-  onClick: () => void | React.FormEventHandler<Element>;
+  onClick: (e) => void | React.FormEventHandler<Element>;
   text: string;
   width?: number;
   height?: number;

--- a/frontend/src/components/atoms/LabeledDefaultButton/index.tsx
+++ b/frontend/src/components/atoms/LabeledDefaultButton/index.tsx
@@ -3,7 +3,7 @@ import LabeledButton from '@atoms/LabeledButton';
 import { ButtonSize } from '@enum/index';
 
 interface Props<T> {
-  onClick?: () => void;
+  onClick?: (e) => void;
   width?: number;
   height?: number;
   text: string;
@@ -48,7 +48,7 @@ const LabeledDefaultButton = ({
 };
 
 LabeledDefaultButton.defaultProps = {
-  onClick: () => {},
+  onClick: (e) => {},
   width: ButtonWidth as number,
   height: ButtonHeight as number,
   color: ButtonColor,

--- a/frontend/src/components/molecules/ChannelList/index.tsx
+++ b/frontend/src/components/molecules/ChannelList/index.tsx
@@ -1,26 +1,51 @@
 import Label from '@atoms/Label';
 import LabeledDefaultButton from '@atoms/LabeledDefaultButton';
+import userState from '@state/user';
+import axios from 'axios';
 import React, { useState } from 'react';
+import { useHistory } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
 import { Container, TextSet, SpaceBetweenDiv, MarginedDiv } from './styles';
 
 interface Props {
+  id: string;
   firstLabelContent?: string;
   secondLabelContent?: string;
   content?: string;
 }
 
 const ChannelList = ({
+  id,
   firstLabelContent,
   secondLabelContent,
   content,
 }: Props): JSX.Element => {
   const [isHover, setHover] = useState<boolean>(false);
-
+  const user = useRecoilValue(userState);
+  const history = useHistory();
   const MouseHover = (): void => setHover(true);
   const MouseOut = (): void => setHover(false);
 
+  const navigateToChannel = (e) => {
+    e.stopPropagation();
+    history.push(`/client/${user.workspaceId}/${id}`);
+  };
+
+  const joinChannel = (e) => {
+    e.stopPropagation();
+    axios.post('/api/channels/userToChannel', {
+      userId: user.id,
+      channelId: id,
+      workspaceId: user.workspaceId,
+    });
+  };
+
   return (
-    <SpaceBetweenDiv onMouseEnter={MouseHover} onMouseLeave={MouseOut}>
+    <SpaceBetweenDiv
+      onMouseEnter={MouseHover}
+      onMouseLeave={MouseOut}
+      onClick={navigateToChannel}
+    >
       <Container>
         <div>{firstLabelContent || 'channel name'}</div>
 
@@ -30,9 +55,16 @@ const ChannelList = ({
         </TextSet>
       </Container>
       <MarginedDiv>
-        {isHover && <LabeledDefaultButton text="view" />}
         {isHover && (
-          <LabeledDefaultButton backgroundColor="green" text="join" />
+          <LabeledDefaultButton onClick={navigateToChannel} text="view" />
+        )}
+        {isHover && (
+          <LabeledDefaultButton
+            onClick={joinChannel}
+            backgroundColor="green"
+            text="join"
+            data-action="join"
+          />
         )}
       </MarginedDiv>
     </SpaceBetweenDiv>

--- a/frontend/src/components/molecules/ChannelList/index.tsx
+++ b/frontend/src/components/molecules/ChannelList/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useHistory, useParams } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import Label from '@atoms/Label';
 import LabeledDefaultButton from '@atoms/LabeledDefaultButton';
@@ -8,21 +8,23 @@ import userState from '@state/user';
 import { Container, TextSet, SpaceBetweenDiv, MarginedDiv } from './styles';
 
 interface Props {
-  id: string;
+  channelId: string;
   firstLabelContent?: string;
   secondLabelContent?: string;
   content?: string;
 }
 
 const ChannelList = ({
-  id,
+  channelId,
   firstLabelContent,
   secondLabelContent,
   content,
 }: Props): JSX.Element => {
-  const [isHover, setHover] = useState<boolean>(false);
   const user = useRecoilValue(userState);
+  const { workspaceId }: { workspaceId: string } = useParams();
   const history = useHistory();
+
+  const [isHover, setHover] = useState<boolean>(false);
   const MouseHover = (): void => setHover(true);
   const MouseOut = (): void => setHover(false);
 
@@ -30,7 +32,7 @@ const ChannelList = ({
     e: React.MouseEvent<HTMLDivElement, MouseEvent>,
   ) => {
     e.stopPropagation();
-    history.push(`/client/${user.workspaceId}/${id}`);
+    history.push(`/client/${workspaceId}/${channelId}`);
   };
 
   return (
@@ -55,7 +57,7 @@ const ChannelList = ({
           <LabeledDefaultButton
             onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
               e.stopPropagation();
-              joinChannel(user.id, id, user.workspaceId);
+              joinChannel(user.id, channelId, workspaceId);
             }}
             backgroundColor="green"
             text="join"

--- a/frontend/src/components/molecules/ChannelList/index.tsx
+++ b/frontend/src/components/molecules/ChannelList/index.tsx
@@ -1,10 +1,10 @@
-import Label from '@atoms/Label';
-import LabeledDefaultButton from '@atoms/LabeledDefaultButton';
-import userState from '@state/user';
-import axios from 'axios';
 import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
+import Label from '@atoms/Label';
+import LabeledDefaultButton from '@atoms/LabeledDefaultButton';
+import { joinChannel } from '@global/api/channel';
+import userState from '@state/user';
 import { Container, TextSet, SpaceBetweenDiv, MarginedDiv } from './styles';
 
 interface Props {
@@ -26,18 +26,11 @@ const ChannelList = ({
   const MouseHover = (): void => setHover(true);
   const MouseOut = (): void => setHover(false);
 
-  const navigateToChannel = (e) => {
+  const navigateToChannel = (
+    e: React.MouseEvent<HTMLDivElement, MouseEvent>,
+  ) => {
     e.stopPropagation();
     history.push(`/client/${user.workspaceId}/${id}`);
-  };
-
-  const joinChannel = (e) => {
-    e.stopPropagation();
-    axios.post('/api/channels/userToChannel', {
-      userId: user.id,
-      channelId: id,
-      workspaceId: user.workspaceId,
-    });
   };
 
   return (
@@ -60,7 +53,7 @@ const ChannelList = ({
         )}
         {isHover && (
           <LabeledDefaultButton
-            onClick={joinChannel}
+            onClick={(e) => joinChannel(e, user.id, id, user.workspaceId)}
             backgroundColor="green"
             text="join"
             data-action="join"

--- a/frontend/src/components/molecules/ChannelList/index.tsx
+++ b/frontend/src/components/molecules/ChannelList/index.tsx
@@ -53,7 +53,10 @@ const ChannelList = ({
         )}
         {isHover && (
           <LabeledDefaultButton
-            onClick={(e) => joinChannel(e, user.id, id, user.workspaceId)}
+            onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+              e.stopPropagation();
+              joinChannel(user.id, id, user.workspaceId);
+            }}
             backgroundColor="green"
             text="join"
             data-action="join"

--- a/frontend/src/components/molecules/ChatHeader/index.tsx
+++ b/frontend/src/components/molecules/ChatHeader/index.tsx
@@ -1,25 +1,24 @@
-import React, { useEffect } from 'react';
+import React from 'react';
+import { useRecoilState } from 'recoil';
+import { useParams } from 'react-router-dom';
 import { MdPeople } from 'react-icons/md';
-import { useRecoilState, useRecoilValue } from 'recoil';
-import { channelListState } from '@state/Channel';
-import userState from '@state/user';
-import { channelInfoModalState } from 'src/state/modal';
+import { channelInfoModalState } from '@state/modal';
+import { useChannelQuery } from '@hook/useChannels';
 import { Container, StyledLabeledButton, StyledIconButton } from './styles';
 
 const ChatHeader = (): JSX.Element => {
+  const { channelId }: { channelId: string } = useParams();
   const [, setIsOpen] = useRecoilState(channelInfoModalState);
-  const user = useRecoilValue(userState);
-  const channelList = useRecoilValue(channelListState);
+  const { isLoading, isError, data } = useChannelQuery(channelId);
+
+  if (isLoading) return <div>Loading</div>;
+  if (isError) return <div>Error</div>;
 
   const open = () => setIsOpen(true);
 
-  const channelName = user.channelId
-    ? channelList[user.channelId - 1]
-    : '# channel name';
-
   return (
     <Container>
-      <StyledLabeledButton text={channelName?.name} onClick={open} />
+      <StyledLabeledButton text={data.name} onClick={open} />
       <StyledIconButton icon={MdPeople} onClick={open} />
     </Container>
   );

--- a/frontend/src/components/molecules/MentionPopup/index.tsx
+++ b/frontend/src/components/molecules/MentionPopup/index.tsx
@@ -28,7 +28,6 @@ const MentionPopup = ({
         url: `/api/users/workspaces?workspaceId=${1}`, // workspaceId that this channel belongs to
         baseURL: '/',
       });
-      console.log(data.users);
       setUsers(data.users);
     };
     getUsers();

--- a/frontend/src/components/organisms/BrowseChannelList/index.tsx
+++ b/frontend/src/components/organisms/BrowseChannelList/index.tsx
@@ -61,9 +61,10 @@ const BrowseChannelList = (): JSX.Element => {
     const { channels } = data;
     return (
       <>
-        {channels.map(({ id, name, private:isPrivate, description }) => {
+        {channels.map(({ id, name, private: isPrivate, description }) => {
           return (
             <ChannelList
+              id={id}
               firstLabelContent={`${CHANNELTYPE[isPrivate]} ${id} ${name}`}
               secondLabelContent={description}
               key={`BrowseChannelList${id}`}

--- a/frontend/src/components/organisms/BrowseChannelList/index.tsx
+++ b/frontend/src/components/organisms/BrowseChannelList/index.tsx
@@ -64,7 +64,7 @@ const BrowseChannelList = (): JSX.Element => {
         {channels.map(({ id, name, private: isPrivate, description }) => {
           return (
             <ChannelList
-              id={id}
+              channelId={id}
               firstLabelContent={`${CHANNELTYPE[isPrivate]} ${id} ${name}`}
               secondLabelContent={description}
               key={`BrowseChannelList${id}`}

--- a/frontend/src/components/organisms/ChannelJoinFooter/index.tsx
+++ b/frontend/src/components/organisms/ChannelJoinFooter/index.tsx
@@ -1,43 +1,30 @@
 import React, { useMemo } from 'react';
 import { useRecoilValue } from 'recoil';
-import axios from 'axios';
 import LabeledButton from '@atoms/LabeledButton';
 import { ChatInputSize } from '@enum/index';
 import userState from '@state/user';
+import { joinChannel } from '@global/api/channel';
 import { Container } from './styles';
 
 interface Props {
   channelName: string;
 }
 
-const addUserToChannel = async (
-  userId: number,
-  channelId: number,
-  workspaceId: number,
-) => {
-  await axios.post('/api/channels/userToChannel', {
-    userId,
-    channelId,
-    workspaceId,
-  });
-  window.location.href = window.location.href;
-};
-
 const ChatInputBackGround = ({ channelName }: Props): JSX.Element => {
+  const user = useRecoilValue(userState);
+
   const { width, height } = useMemo(() => {
     return ChatInputSize;
   }, []);
-
-  const user = useRecoilValue(userState);
 
   return (
     <Container width={width} height={height}>
       <div>#{channelName}을(를) 보고 있습니다.</div>
       <div>
         <LabeledButton
-          onClick={() => {
-            addUserToChannel(user.id, user.channelId, user.workspaceId);
-          }}
+          onClick={(e) =>
+            joinChannel(e, user.id, user.channelId, user.workspaceId)
+          }
           text="채널 참여"
         />
         <LabeledButton onClick={() => {}} text="추가 정보 보기" />

--- a/frontend/src/components/organisms/ChannelJoinFooter/index.tsx
+++ b/frontend/src/components/organisms/ChannelJoinFooter/index.tsx
@@ -22,9 +22,10 @@ const ChatInputBackGround = ({ channelName }: Props): JSX.Element => {
       <div>#{channelName}을(를) 보고 있습니다.</div>
       <div>
         <LabeledButton
-          onClick={(e) =>
-            joinChannel(e, user.id, user.channelId, user.workspaceId)
-          }
+          onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+            e.stopPropagation();
+            joinChannel(user.id, user.channelId, user.workspaceId);
+          }}
           text="채널 참여"
         />
         <LabeledButton onClick={() => {}} text="추가 정보 보기" />

--- a/frontend/src/components/organisms/ChannelJoinFooter/index.tsx
+++ b/frontend/src/components/organisms/ChannelJoinFooter/index.tsx
@@ -1,7 +1,7 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import { useRecoilValue } from 'recoil';
+import { useParams } from 'react-router-dom';
 import LabeledButton from '@atoms/LabeledButton';
-import { ChatInputSize } from '@enum/index';
 import userState from '@state/user';
 import { joinChannel } from '@global/api/channel';
 import { Container } from './styles';
@@ -12,19 +12,17 @@ interface Props {
 
 const ChatInputBackGround = ({ channelName }: Props): JSX.Element => {
   const user = useRecoilValue(userState);
-
-  const { width, height } = useMemo(() => {
-    return ChatInputSize;
-  }, []);
+  const { workspaceId, channelId }: { workspaceId: string; channelId: string } =
+    useParams();
 
   return (
-    <Container width={width} height={height}>
+    <Container>
       <div>#{channelName}을(를) 보고 있습니다.</div>
       <div>
         <LabeledButton
           onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
             e.stopPropagation();
-            joinChannel(user.id, user.channelId, user.workspaceId);
+            joinChannel(user.id, channelId, workspaceId);
           }}
           text="채널 참여"
         />

--- a/frontend/src/components/organisms/ChannelJoinFooter/styles.ts
+++ b/frontend/src/components/organisms/ChannelJoinFooter/styles.ts
@@ -1,14 +1,8 @@
 import styled from 'styled-components';
 
-interface Props {
-  width: number;
-  height: number;
-}
-
-export const Container = styled.div<Props>`
+export const Container = styled.div`
   display: flex;
   flex-direction: column;
-  width: inherit;
   height: 10vh;
 
   align-items: center;

--- a/frontend/src/components/organisms/ChannelMembers/index.tsx
+++ b/frontend/src/components/organisms/ChannelMembers/index.tsx
@@ -36,7 +36,7 @@ const ChannelMembers = (): JSX.Element => {
     };
     getUsers();
   }, []);
-
+  console.log(users);
   return (
     <Container>
       <StyledInput

--- a/frontend/src/components/organisms/CreateChannelModal/index.tsx
+++ b/frontend/src/components/organisms/CreateChannelModal/index.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
-import LabeledButton from '@atoms/LabeledButton';
+import { useParams } from 'react-router-dom';
 import Label from '@atoms/Label';
+import LabeledButton from '@atoms/LabeledButton';
 import useInputs from '@hook/useInputs';
 import { channelCreateModalState } from '@state/modal';
 import userState from '@state/user';
@@ -27,10 +28,12 @@ const initialData = {
 };
 
 const CreateChannelModal = (): JSX.Element => {
+  const user = useRecoilValue(userState);
+  const { workspaceId }: { workspaceId: string } = useParams();
+
   const [isOpen, setIsOpen] = useRecoilState(channelCreateModalState);
   const [isPrivate, setIsPrivate] = useState(false);
   const [{ name, description }, onChange, clear] = useInputs(initialData);
-  const user = useRecoilValue(userState);
 
   const createChannelAndClose = async () => {
     if (!name) return;
@@ -38,9 +41,9 @@ const CreateChannelModal = (): JSX.Element => {
       name,
       isPrivate,
       description,
-      user.workspaceId,
+      workspaceId,
     );
-    joinChannel(user.id, channel.id, user.workspaceId);
+    joinChannel(user.id, channel.id, workspaceId);
     clear();
     setIsOpen(false);
   };
@@ -54,7 +57,7 @@ const CreateChannelModal = (): JSX.Element => {
           ) : (
             <HeaderLabel text="Create a channel" />
           )}
-          <LabeledButton text="x" />
+          <LabeledButton onClick={() => setIsOpen(false)} text="x" />
         </Header>
         <ContentContainer>
           <StyledLightLabel text="Channels are where your team communicates.." />

--- a/frontend/src/components/organisms/CreateChannelModal/index.tsx
+++ b/frontend/src/components/organisms/CreateChannelModal/index.tsx
@@ -1,10 +1,11 @@
 import React, { useState } from 'react';
-import { useRecoilState } from 'recoil';
-import axios from 'axios';
-import { channelCreateModalState } from '@state/modal';
-import useInputs from '@hook/useInputs';
-import Label from '@atoms/Label';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import LabeledButton from '@atoms/LabeledButton';
+import Label from '@atoms/Label';
+import useInputs from '@hook/useInputs';
+import { channelCreateModalState } from '@state/modal';
+import userState from '@state/user';
+import { createChanel, joinChannel } from '@global/api/channel';
 import {
   Container,
   ContentContainer,
@@ -29,18 +30,17 @@ const CreateChannelModal = (): JSX.Element => {
   const [isOpen, setIsOpen] = useRecoilState(channelCreateModalState);
   const [isPrivate, setIsPrivate] = useState(false);
   const [{ name, description }, onChange, clear] = useInputs(initialData);
+  const user = useRecoilValue(userState);
 
-  const createChannel = async () => {
+  const createChannelAndClose = async () => {
     if (!name) return;
-    await axios({
-      method: 'POST',
-      url: 'api/channels',
-      data: {
-        name,
-        type: isPrivate ? 'private' : 'public',
-        description,
-      },
-    });
+    const { channel } = await createChanel(
+      name,
+      isPrivate,
+      description,
+      user.workspaceId,
+    );
+    joinChannel(user.id, channel.id, user.workspaceId);
     clear();
     setIsOpen(false);
   };
@@ -84,7 +84,7 @@ const CreateChannelModal = (): JSX.Element => {
           </ToggleContainer>
         </ContentContainer>
         <Footer>
-          <StyledLabeledButton text="Create" onClick={createChannel} />
+          <StyledLabeledButton text="Create" onClick={createChannelAndClose} />
         </Footer>
       </Container>
     </StyledModal>

--- a/frontend/src/components/organisms/SidebarChannelInfoModal/index.tsx
+++ b/frontend/src/components/organisms/SidebarChannelInfoModal/index.tsx
@@ -4,7 +4,7 @@ import Modal from '@atoms/Modal';
 import { useRecoilState } from 'recoil';
 import { sidebarChannelInfoModalState } from 'src/state/modal';
 import axios from 'axios';
-import { Container } from './styles';
+import { Container, StyledModal } from './styles';
 
 const SidebarChannelInfoModal = (): JSX.Element => {
   const [isOpen, setIsOpen] = useRecoilState(sidebarChannelInfoModalState);
@@ -22,7 +22,7 @@ const SidebarChannelInfoModal = (): JSX.Element => {
   };
 
   return (
-    <Modal
+    <StyledModal
       isOpen={isOpen.status}
       onClose={() => setIsOpen({ status: false, channelId: isOpen.channelId })}
     >
@@ -57,7 +57,7 @@ const SidebarChannelInfoModal = (): JSX.Element => {
         <LabeledButton text="새 섹션 생성" onClick={() => {}} />
         <LabeledButton text="사이드바 편집" onClick={() => {}} />
       </Container>
-    </Modal>
+    </StyledModal>
   );
 };
 

--- a/frontend/src/components/organisms/SidebarChannelInfoModal/styles.ts
+++ b/frontend/src/components/organisms/SidebarChannelInfoModal/styles.ts
@@ -1,3 +1,4 @@
+import Modal from '@atoms/Modal';
 import styled from 'styled-components';
 
 interface Props {
@@ -5,8 +6,14 @@ interface Props {
   height: number;
 }
 
+export const StyledModal = styled(Modal)`
+  max-width: 360px;
+  min-width: 200px;
+`;
+
 export const Container = styled.div<Props>`
   display: flex;
+  background-color: white;
   flex-direction: column;
   border-radius: 16px;
   padding: 12px 24px;

--- a/frontend/src/components/organisms/WorkspaceContent/index.tsx
+++ b/frontend/src/components/organisms/WorkspaceContent/index.tsx
@@ -1,83 +1,40 @@
-import React, { useEffect, useState } from 'react';
-import { useRecoilState, useRecoilValue } from 'recoil';
-import axios from 'axios';
-import Label from '@atoms/Label';
-import LabeledDefaultButton from '@atoms/LabeledDefaultButton';
+import React from 'react';
+import { useRecoilValue } from 'recoil';
+import { useParams } from 'react-router-dom';
 import ChatHeader from '@molecules/ChatHeader';
 import ChatInputBackground from '@organisms/ChatInputBackground';
 import ChatContent from '@organisms/ChatContent';
 import ChannelJoinFooter from '@organisms/ChannelJoinFooter';
 import userState from '@state/user';
-import { channelListState } from '@state/Channel';
-import { Container, MarginedDiv } from './style';
-
-const getChannelById = (id: string) => {
-  const [channel, setChannel] = useState();
-  useEffect(() => {
-    (async () => {
-      const response = await axios.get(`/api/channels/${id}`);
-      setChannel(response.data.channel);
-    })();
-  }, [id]);
-
-  return { channel /* loading, error */ };
-};
+import { useChannelListQuery, useChannelQuery } from '@hook/useChannels';
+import { Container } from './style';
 
 const WorkspaceContent = (): JSX.Element => {
   const user = useRecoilValue(userState);
-  const [channelList, setChannelList] = useRecoilState(channelListState);
+  const { workspaceId, channelId }: { workspaceId: string; channelId: string } =
+    useParams();
 
-  useEffect(() => {
-    if (!user.workspaceId) return;
-    const getChannelList = async () => {
-      const res = await axios.get(
-        `/api/channels/channelsThatUserIn?userId=${user.id}&workspaceId=${user.workspaceId}`,
-      );
-      setChannelList(res.data.channels);
-    };
-    getChannelList();
-  }, [user.workspaceId]);
+  const channelListQuery = useChannelListQuery(user.id, workspaceId);
+  const channelQuery = useChannelQuery(channelId);
 
-  const isUserInCurrentChannel = channelList.find(
-    (channel) => String(channel.id) === user.channelId,
-  );
+  if (channelListQuery.isLoading || channelQuery.isLoading) {
+    return <div>Loading</div>;
+  }
+  if (channelListQuery.isError || channelQuery.isError) return <div>Error</div>;
 
-  const currentChannel = getChannelById(user.channelId);
-  const channelTitleText = currentChannel.channel
-    ? currentChannel.channel.name
-    : '로딩';
-
-  const ChannelTitle: JSX.Element = <Label text={`# ${channelTitleText}`} />;
-  const ExplainContent: JSX.Element | null = (
-    <Label color="grey" text="channel explain " />
-  );
-
-  const Title: JSX.Element = (
-    <MarginedDiv>
-      {ChannelTitle}
-      {ExplainContent}
-    </MarginedDiv>
+  const isUserInCurrentChannel = channelListQuery.data.find(
+    (channel) => String(channel.id) === channelId,
   );
 
   const InputBar: JSX.Element = isUserInCurrentChannel ? (
     <ChatInputBackground />
   ) : (
-    <ChannelJoinFooter channelName={channelTitleText} />
-  );
-  const RightButton = (
-    <LabeledDefaultButton
-      text="무야호"
-      onClick={() => {}}
-      width={30}
-      height={30}
-      color={'black'}
-      backgroundColor={'white'}
-    />
+    <ChannelJoinFooter channelName={channelQuery.data.name} />
   );
 
   return (
     <Container>
-      <ChatHeader title={Title} content={null} rightButton={RightButton} />
+      <ChatHeader />
       <ChatContent inputBar={InputBar} />
     </Container>
   );

--- a/frontend/src/components/organisms/WorkspaceListContent/index.tsx
+++ b/frontend/src/components/organisms/WorkspaceListContent/index.tsx
@@ -35,7 +35,7 @@ const WorkSpaceLists = ({
             <StyledSelectWorkspace firstLabelContent={name} content={count} />
             <StyledLabeledButton
               text="실행"
-              onClick={() => history.push(`client/${id}/1`)}
+              onClick={() => history.push(`client/${id}/browse-channels`)}
             />
           </StyledDiv>
         );

--- a/frontend/src/components/organisms/WorkspaceSidebar/index.tsx
+++ b/frontend/src/components/organisms/WorkspaceSidebar/index.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect } from 'react';
-import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
-import { NavLink } from 'react-router-dom';
+import React from 'react';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { NavLink, useParams } from 'react-router-dom';
 import SidebarDivision from '@molecules/SidebarDivision';
 import SidebarChannelElement from '@molecules/SidebarChannelElement';
 import SidebarAddElement from '@molecules/SidebarAddElement';
@@ -9,44 +9,33 @@ import {
   sidebarChannelInfoModalState,
 } from '@state/modal';
 import userState from '@state/user';
-import { channelListState } from '@state/Channel';
+import { useChannelListQuery } from '@hook/useChannels';
 import { Container } from './style';
-import axios from 'axios';
 
 const WorkspaceSidebar = (): JSX.Element => {
-  // const user = useRecoilValue(userState);
-  const [user, setUser] = useRecoilState(userState);
+  const user = useRecoilValue(userState);
+  const { workspaceId }: { workspaceId: string } = useParams();
+
   const setIsChannelCreateModalOpen = useSetRecoilState(
     channelCreateModalState,
   );
-  const [isSidebarChannelInfoModalOpen, setIsSidebarChannelInfoModalOpen] =
-    useRecoilState(sidebarChannelInfoModalState);
-  // const channelList = useRecoilValue(
-  //   channelListFromServerState({
-  //     userId: sessionStorage.getItem('id'),
-  //     workspaceId: sessionStorage.getItem('workspaceId'),
-  //   }),
-  // );
+  const setIsSidebarChannelInfoModalOpen = useSetRecoilState(
+    sidebarChannelInfoModalState,
+  );
 
-  const [channelList, setChannelList] = useRecoilState(channelListState);
+  const { isLoading, isError, data } = useChannelListQuery(
+    user.id,
+    workspaceId,
+  );
 
-  useEffect(() => {
-    if (!user.workspaceId) return;
-
-    const getChannelList = async () => {
-      const res = await axios.get(
-        `/api/channels/channelsThatUserIn?userId=${user.id}&workspaceId=${user.workspaceId}`,
-      );
-      setChannelList(res.data.channels);
-    };
-    getChannelList();
-  }, [user.workspaceId]);
+  if (isLoading) return <div>Loading</div>;
+  if (isError) return <div>Error</div>;
 
   return (
     <Container>
       <SidebarDivision label="Channels" options type="Channels" />
       <NavLink
-        to={`/client/${user.workspaceId}/browse-channels`}
+        to={`/client/${workspaceId}/browse-channels`}
         style={{ textDecoration: 'none', color: 'black' }}
         activeStyle={{ color: 'red' }}
       >
@@ -60,14 +49,11 @@ const WorkspaceSidebar = (): JSX.Element => {
         />
       </NavLink>
 
-      {channelList.map((channel) => {
-        {
-          /* {channelList.channels.map((channel) => { */
-        }
+      {data.map((channel) => {
         return (
           <NavLink
             key={channel.id}
-            to={`/client/${user.workspaceId}/${channel.id}`}
+            to={`/client/${workspaceId}/${channel.id}`}
             style={{ textDecoration: 'none', color: 'black' }}
             activeStyle={{ color: 'red' }}
           >

--- a/frontend/src/components/pages/Workspace/index.tsx
+++ b/frontend/src/components/pages/Workspace/index.tsx
@@ -5,6 +5,7 @@ import WorkspaceTemplate from '@templates/Workspace';
 import { useRecoilState } from 'recoil';
 import userState from '@state/user';
 import BrowseContent from '@organisms/BrowseContent';
+import axios from 'axios';
 
 const Workspace = (): JSX.Element => {
   const { workspaceId, channelId }: { workspaceId: string; channelId: string } =
@@ -12,12 +13,22 @@ const Workspace = (): JSX.Element => {
   const [user, setUser] = useRecoilState(userState);
 
   useEffect(() => {
-    setUser((prevState) => ({
-      ...prevState,
-      workspaceId,
-      channelId,
-    }));
-  }, [workspaceId, channelId]);
+    const getUserHasWorkspace = async () => {
+      const res = await axios.get(
+        `/api/userHasWorkspaces?userId=${user.id}&workspaceId=${workspaceId}`,
+      );
+      const { id, nickname, description, theme } = res.data.userHasWorkspace;
+
+      setUser((prevState) => ({
+        ...prevState,
+        userHasWorkspaceId: id,
+        nickname,
+        description,
+        theme,
+      }));
+    };
+    getUserHasWorkspace();
+  }, [workspaceId]);
 
   const workspaceContent =
     channelId === 'browse-channels' ? <BrowseContent /> : <WorkspaceContent />;

--- a/frontend/src/components/pages/Workspace/index.tsx
+++ b/frontend/src/components/pages/Workspace/index.tsx
@@ -20,11 +20,7 @@ const Workspace = (): JSX.Element => {
   }, [workspaceId, channelId]);
 
   const workspaceContent =
-    user.channelId === 'browse-channels' ? (
-      <BrowseContent />
-    ) : (
-      <WorkspaceContent />
-    );
+    channelId === 'browse-channels' ? <BrowseContent /> : <WorkspaceContent />;
 
   return (
     <>

--- a/frontend/src/components/templates/Workspace/index.tsx
+++ b/frontend/src/components/templates/Workspace/index.tsx
@@ -1,14 +1,16 @@
 import React, { Suspense } from 'react';
-import { useRecoilState } from 'recoil';
+import { useRecoilValue } from 'recoil';
 import WorkspaceHeader from '@organisms/WorkspaceHeader';
 import WorkspaceSidebar from '@organisms/WorkspaceSidebar';
 import CreateChannelModal from '@organisms/CreateChannelModal';
 import ChannelInfoModal from '@organisms/ChannelInfoModal';
 import ChannelDescriptionModal from '@organisms/ChannelDescriptionModal';
+import SidebarChannelInfoModal from '@organisms/SidebarChannelInfoModal';
 import {
   channelCreateModalState,
   channelDescriptionModalState,
   channelInfoModalState,
+  sidebarChannelInfoModalState,
 } from '@state/modal';
 import { RowDiv } from './styles';
 
@@ -17,9 +19,10 @@ interface Props {
 }
 
 const WorkspaceTemplate = ({ Content }: Props): JSX.Element => {
-  const [channelModal] = useRecoilState(channelCreateModalState);
-  const [infoModal] = useRecoilState(channelInfoModalState);
-  const [descriptionModal] = useRecoilState(channelDescriptionModalState);
+  const channelCreateModal = useRecoilValue(channelCreateModalState);
+  const channelInfoModal = useRecoilValue(channelInfoModalState);
+  const channelDescriptionModal = useRecoilValue(channelDescriptionModalState);
+  const sidebarChannelModal = useRecoilValue(sidebarChannelInfoModalState);
 
   return (
     <>
@@ -30,9 +33,10 @@ const WorkspaceTemplate = ({ Content }: Props): JSX.Element => {
           {Content}
         </RowDiv>
       </Suspense>
-      {channelModal && <CreateChannelModal />}
-      {infoModal && <ChannelInfoModal />}
-      {descriptionModal && <ChannelDescriptionModal />}
+      {channelCreateModal && <CreateChannelModal />}
+      {channelInfoModal && <ChannelInfoModal />}
+      {channelDescriptionModal && <ChannelDescriptionModal />}
+      {sidebarChannelModal && <SidebarChannelInfoModal />}
     </>
   );
 };

--- a/frontend/src/global/api/channel/index.ts
+++ b/frontend/src/global/api/channel/index.ts
@@ -1,0 +1,16 @@
+import axios from 'axios';
+
+// refresh required
+export const joinChannel = (
+  e: MouseEvent,
+  userId: string,
+  channelId: string,
+  workspaceId: string,
+): void => {
+  e.stopPropagation();
+  axios.post('/api/channels/userToChannel', {
+    userId,
+    channelId,
+    workspaceId,
+  });
+};

--- a/frontend/src/global/api/channel/index.ts
+++ b/frontend/src/global/api/channel/index.ts
@@ -2,15 +2,28 @@ import axios from 'axios';
 
 // refresh required
 export const joinChannel = (
-  e: MouseEvent,
   userId: string,
   channelId: string,
   workspaceId: string,
 ): void => {
-  e.stopPropagation();
   axios.post('/api/channels/userToChannel', {
     userId,
     channelId,
     workspaceId,
   });
+};
+
+export const createChanel = async (
+  name: string,
+  isPrivate: boolean,
+  description: string,
+  workspaceId: string,
+): Promise<any> => {
+  const res = await axios.post('/api/channels', {
+    name,
+    private: isPrivate,
+    description,
+    workspaceId,
+  });
+  return res.data;
 };

--- a/frontend/src/hooks/useChannels.ts
+++ b/frontend/src/hooks/useChannels.ts
@@ -1,0 +1,17 @@
+import axios from 'axios';
+import { useQuery } from 'react-query';
+
+export const useChannelListQuery = (userId: string, workspaceId: string) => {
+  return useQuery(
+    ['channels', userId, workspaceId],
+    async () => {
+      const res = await axios.get(
+        `/api/channels/channelsThatUserIn?userId=${userId}&workspaceId=${workspaceId}`,
+      );
+      return res.data.channels;
+    },
+    {
+      enabled: !!workspaceId,
+    },
+  );
+};

--- a/frontend/src/hooks/useChannels.ts
+++ b/frontend/src/hooks/useChannels.ts
@@ -15,3 +15,10 @@ export const useChannelListQuery = (userId: string, workspaceId: string) => {
     },
   );
 };
+
+export const useChannelQuery = (id: string) => {
+  return useQuery(['channel', id], async () => {
+    const res = await axios.get(`/api/channels/${id}`);
+    return res.data.channel;
+  });
+};

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import App from './App';
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,5 +1,0 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import App from './App';
-
-ReactDOM.render(<App />, document.getElementById('root'));


### PR DESCRIPTION
## 📃 PR 제목

feat: react-query로 리팩토링과 recoil & useParams로 현재 상태 저장
resolves #139 
진행중... #115 

## 📃 작업 목록

- react-query로 일부 api 리팩토링
- recoil & useParams로 user, userHasWorkspace, workspaceId, channelId 저장
- 채널 생성 가능
- 채널 참가 가능

**안쓰는 내용을 많이 지웠습니다. 특히 WorkspaceContent**

## 📃 주의 사항

- 채널 생성과 참가, 디비에 변동이 있는 모든 작업들은 아직 실시간으로 반영이 되지 않습니다. 리팩토링 끝나면 소켓으로 동기화 할 예정이예요.

## 📃 추가 메모 사항

민욱님 #136
진성님 #139 
이슈 등록했으니 확인 부탁드립니다. 
