### PR TITLE
스레드 컨텐트가 리플라이에서도 재사용가능하도록 추상화

### DIFF
--- a/frontend/src/components/atoms/ImageButton/index.tsx
+++ b/frontend/src/components/atoms/ImageButton/index.tsx
@@ -3,7 +3,7 @@ import { SetterOrUpdater } from 'recoil';
 import Container from './styles';
 
 interface Props {
-  onClick: () => void | SetterOrUpdater<boolean>;
+  onClick: (e: React.MouseEvent<HTMLElement>) => void | SetterOrUpdater<any>;
   width?: number;
   height?: number;
   image: string;

--- a/frontend/src/components/molecules/MessageContent/MessageActions/index.tsx
+++ b/frontend/src/components/molecules/MessageContent/MessageActions/index.tsx
@@ -1,0 +1,204 @@
+import React, { useRef, useState } from 'react';
+import { useRecoilValue, useRecoilState } from 'recoil';
+import { useParams } from 'react-router-dom';
+import EmojiModal from '@organisms/EmojiModal';
+import useRefLocate from '@hook/useRefLocate';
+import userState from '@state/user';
+import { replyToggleState } from '@state/workspace';
+import { Message } from '@global/type';
+import { onEmojiSet } from '@global/util/reaction';
+import { checkIsInReplySide } from '@global/util/reply';
+import { removeMessage } from '@global/util/message';
+import { BsEmojiSmile, BsBookmark } from 'react-icons/bs';
+import { BiMessageRoundedDetail, BiDotsVerticalRounded } from 'react-icons/bi';
+import { RiShareForwardLine } from 'react-icons/ri';
+import {
+  Container,
+  ThreadActionsGroup,
+  ActionButton,
+  ActionsMenu,
+  MenuItems,
+  MenuItem,
+  MenuSeparator,
+  MenuSeparatorHr,
+  MenuItemButton,
+} from './styles';
+
+interface Props {
+  messageObject: Message;
+  channelName: string[];
+  setUpdateState: (arg: boolean) => void;
+}
+
+const MessageActions = ({
+  messageObject,
+  channelName,
+  setUpdateState,
+}: Props): JSX.Element => {
+  const dotsVerticalButtonRef = useRef(null);
+  const emojiButtonRef = useRef(null);
+  const [modalState, setModalState] = useState(false);
+
+  const [dotsVerticalXWidth, dotsVerticalYHeight] = useRefLocate(
+    dotsVerticalButtonRef,
+    50,
+  );
+  const [emojiXWidth, emojiYHeight] = useRefLocate(emojiButtonRef, 50);
+
+  const { channelId }: { channelId: string } = useParams();
+  const user = useRecoilValue(userState);
+  const [replyToggle, setReplyToggle] = useRecoilState(replyToggleState);
+
+  const [isEmojiOpen, setIsEmojiOpen] = useState(false);
+
+  const isInReplySide = checkIsInReplySide(messageObject, replyToggle);
+
+  const myMessageActionMenus = (
+    <MenuItems>
+      <MenuItem>
+        <MenuItemButton text="댓글에 대한 알림 끄기" onClick={() => {}} />
+      </MenuItem>
+      <MenuSeparator>
+        <MenuSeparatorHr />
+      </MenuSeparator>
+      <MenuItem>
+        <MenuItemButton text="읽지 않음으로 표시" onClick={() => {}} />
+      </MenuItem>
+      <MenuItem>
+        <MenuItemButton text="이에 대한 리마인더 받기" onClick={() => {}} />
+      </MenuItem>
+      <MenuSeparator>
+        <MenuSeparatorHr />
+      </MenuSeparator>
+      <MenuItem>
+        <MenuItemButton text="링크 복사" onClick={() => {}} />
+      </MenuItem>
+      <MenuSeparator>
+        <MenuSeparatorHr />
+      </MenuSeparator>
+      <MenuItem>
+        <MenuItemButton text="채널에 고정" onClick={() => {}} />
+      </MenuItem>
+      <MenuSeparator>
+        <MenuSeparatorHr />
+      </MenuSeparator>
+      <MenuItem>
+        <MenuItemButton
+          text="메시지 편집"
+          onClick={() => {
+            setUpdateState(true);
+            setModalState(false);
+          }}
+        />
+      </MenuItem>
+      <MenuItem>
+        <MenuItemButton
+          text="메시지 삭제"
+          color="#e01e5a"
+          onClick={() =>
+            removeMessage(
+              messageObject,
+              replyToggle,
+              setReplyToggle,
+              Number(channelId),
+              user.socket,
+            )
+          }
+        />
+      </MenuItem>
+    </MenuItems>
+  );
+
+  const otherMessageActionMenus = (
+    <MenuItems>
+      <MenuItem>
+        <MenuItemButton text="새 댓글이 달리면 알림 받기" onClick={() => {}} />
+      </MenuItem>
+      <MenuSeparator>
+        <MenuSeparatorHr />
+      </MenuSeparator>
+      <MenuItem>
+        <MenuItemButton text="읽지 않음으로 표시" onClick={() => {}} />
+      </MenuItem>
+      <MenuItem>
+        <MenuItemButton text="이에 대한 리마인더 받기" onClick={() => {}} />
+      </MenuItem>
+      <MenuSeparator>
+        <MenuSeparatorHr />
+      </MenuSeparator>
+      <MenuItem>
+        <MenuItemButton text="링크 복사" onClick={() => {}} />
+      </MenuItem>
+      <MenuSeparator>
+        <MenuSeparatorHr />
+      </MenuSeparator>
+      <MenuItem>
+        <MenuItemButton text="채널에 고정" onClick={() => {}} />
+      </MenuItem>
+    </MenuItems>
+  );
+
+  return (
+    <Container>
+      <ThreadActionsGroup>
+        <ActionButton
+          customRef={emojiButtonRef}
+          onClick={() => {
+            setIsEmojiOpen(true);
+          }}
+          icon={BsEmojiSmile}
+        />
+        {!isInReplySide && (
+          <ActionButton
+            customRef={dotsVerticalButtonRef}
+            onClick={() => {
+              setReplyToggle({
+                isOpened: true,
+                message: messageObject,
+                channelName,
+              });
+            }}
+            icon={BiMessageRoundedDetail}
+          />
+        )}
+        {!isInReplySide && (
+          <ActionButton onClick={() => {}} icon={RiShareForwardLine} />
+        )}
+        <ActionButton onClick={() => {}} icon={BsBookmark} />
+        <ActionButton
+          customRef={dotsVerticalButtonRef}
+          onClick={() => {
+            setModalState(true);
+          }}
+          icon={BiDotsVerticalRounded}
+        />
+      </ThreadActionsGroup>
+      <ActionsMenu
+        xWidth={dotsVerticalXWidth - 250}
+        yHeight={dotsVerticalYHeight}
+        isOpened={modalState}
+        onClose={() => setModalState(false)}
+        customRef={dotsVerticalButtonRef}
+      >
+        {messageObject.userHasWorkspaceId === user.userHasWorkspaceId
+          ? myMessageActionMenus
+          : otherMessageActionMenus}
+      </ActionsMenu>
+      <EmojiModal
+        customRef={emojiButtonRef}
+        xWidth={emojiXWidth - 250}
+        yHeight={emojiYHeight}
+        isOpen={isEmojiOpen}
+        close={() => setIsEmojiOpen(false)}
+        onEmojiSet={onEmojiSet(
+          user,
+          messageObject.id,
+          messageObject.threadId,
+          Number(channelId),
+        )}
+      />
+    </Container>
+  );
+};
+
+export default MessageActions;

--- a/frontend/src/components/molecules/MessageContent/MessageActions/index.tsx
+++ b/frontend/src/components/molecules/MessageContent/MessageActions/index.tsx
@@ -5,10 +5,9 @@ import EmojiModal from '@organisms/EmojiModal';
 import useRefLocate from '@hook/useRefLocate';
 import userState from '@state/user';
 import { replyToggleState } from '@state/workspace';
-import { Message } from '@global/type';
-import { onEmojiSet } from '@global/util/reaction';
-import { checkIsInReplySide } from '@global/util/reply';
 import { removeMessage } from '@global/util/message';
+import { onEmojiSet } from '@global/util/reaction';
+import { Message } from '@global/type';
 import { BsEmojiSmile, BsBookmark } from 'react-icons/bs';
 import { BiMessageRoundedDetail, BiDotsVerticalRounded } from 'react-icons/bi';
 import { RiShareForwardLine } from 'react-icons/ri';
@@ -28,12 +27,14 @@ interface Props {
   messageObject: Message;
   channelName: string[];
   setUpdateState: (arg: boolean) => void;
+  isInReplySide: boolean;
 }
 
 const MessageActions = ({
   messageObject,
   channelName,
   setUpdateState,
+  isInReplySide,
 }: Props): JSX.Element => {
   const dotsVerticalButtonRef = useRef(null);
   const emojiButtonRef = useRef(null);
@@ -50,8 +51,6 @@ const MessageActions = ({
   const [replyToggle, setReplyToggle] = useRecoilState(replyToggleState);
 
   const [isEmojiOpen, setIsEmojiOpen] = useState(false);
-
-  const isInReplySide = checkIsInReplySide(messageObject, replyToggle);
 
   const myMessageActionMenus = (
     <MenuItems>

--- a/frontend/src/components/molecules/MessageContent/MessageActions/index.tsx
+++ b/frontend/src/components/molecules/MessageContent/MessageActions/index.tsx
@@ -99,7 +99,7 @@ const MessageActions = ({
               messageObject,
               replyToggle,
               setReplyToggle,
-              Number(channelId),
+              channelId,
               user.socket,
             )
           }
@@ -193,7 +193,7 @@ const MessageActions = ({
           user,
           messageObject.id,
           messageObject.threadId,
-          Number(channelId),
+          channelId,
         )}
       />
     </Container>

--- a/frontend/src/components/molecules/MessageContent/MessageActions/styles.ts
+++ b/frontend/src/components/molecules/MessageContent/MessageActions/styles.ts
@@ -1,0 +1,85 @@
+import IconButton from '@atoms/IconButton';
+import LabeledButton from '@atoms/LabeledButton';
+import NoOverlayModal from '@molecules/NoOverlayModal';
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  position: absolute;
+  top: -16px;
+  right: 17px;
+  z-index: 1;
+  display: 'inline-flex';
+`;
+
+export const ThreadActionsGroup = styled.div`
+  background: #ffffff;
+  line-height: 1;
+  margin-left: 8px;
+  padding: 2px;
+  border-radius: 0.375em;
+  display: flex;
+  border: unset;
+  box-shadow: 0 0 0 1px #1d1c1d, 0 1px 3px 0 #000000;
+`;
+
+export const ActionButton = styled(IconButton)`
+  color: #1d1c1d;
+  height: 32px;
+  width: 32px;
+  border-radius: 4px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border 0;
+  cursor: pointer;
+`;
+
+export const ActionsMenu = styled(NoOverlayModal)`
+  width: 250px;
+  height: inherit;
+  border: none;
+  --saf-0: rgba(var(--sk_foreground_low, 29, 28, 29), 0.13);
+  box-shadow: 0 0 0 1px var(--saf-0), 0 4px 12px 0 rgba(0, 0, 0, 0.12);
+  background-color: rgba(var(--sk_foreground_min_solid, 248, 248, 248), 1);
+  border-radius: 6px;
+  padding: 0.1px 0;
+`;
+
+export const MenuItems = styled.div`
+  padding: 12px 0;
+`;
+
+export const MenuItem = styled.div`
+  line-height: 28px;
+  list-style-type: none;
+  padding: 0;
+  margin: 0;
+`;
+
+export const MenuSeparator = styled.div`
+  padding: 8px 0;
+  margin: 0;
+`;
+
+export const MenuSeparatorHr = styled.hr`
+  margin: 0px;
+  border-top: 1px solid rgba(var(--sk_foreground_low, 29, 28, 29), 0.13);
+  border-bottom: 0;
+  margin-block-start: 0.5em;
+  margin-block-end: 0.5em;
+  font-size: 0;
+`;
+
+export const MenuItemButton = styled(LabeledButton)`
+  line-height: 28px;
+  padding: 0 24px;
+  width: 100%;
+  font-size: 15px;
+  text-align: left;
+
+  :hover {
+    background: #1263a3;
+    color: #ffffff;
+  }
+`;

--- a/frontend/src/components/molecules/MessageContent/MessageFileStatusBar/index.tsx
+++ b/frontend/src/components/molecules/MessageContent/MessageFileStatusBar/index.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import {
+  ThreadFileStatusBarLayout,
+  ThreadFileStatusBarContainer,
+} from './styles';
+import ThreadFileStatusElement from '../MessageFileStatusElement';
+
+interface Props {
+  files: File[];
+}
+
+const MessageFileStatusBar = ({ files }: Props): JSX.Element => {
+  return (
+    <>
+      <ThreadFileStatusBarLayout>
+        <ThreadFileStatusBarContainer>
+          {files.map((file, index) => (
+            <ThreadFileStatusElement file={file} key={index} />
+          ))}
+        </ThreadFileStatusBarContainer>
+      </ThreadFileStatusBarLayout>
+    </>
+  );
+};
+
+export default MessageFileStatusBar;

--- a/frontend/src/components/molecules/MessageContent/MessageFileStatusBar/styles.ts
+++ b/frontend/src/components/molecules/MessageContent/MessageFileStatusBar/styles.ts
@@ -1,0 +1,16 @@
+import styled from 'styled-components';
+
+export const ThreadFileStatusBarContainer = styled.div`
+  max-width: 100%;
+  width: 100%;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-auto-rows: 1fr;
+  gap: 10px 20px;
+`;
+
+export const ThreadFileStatusBarLayout = styled.div`
+  max-width: 100%;
+  width: 730px;
+  margin-bottom: 10px;
+`;

--- a/frontend/src/components/molecules/MessageContent/MessageFileStatusElement/index.tsx
+++ b/frontend/src/components/molecules/MessageContent/MessageFileStatusElement/index.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import {
+  ThreadFileStatusElementImage,
+  ThreadMdTextSnippet,
+  ThreadFileStatusLayOut,
+} from './styles';
+
+interface Props {
+  file: File;
+}
+
+const MessageFileStatusElement = ({ file }: Props): JSX.Element => {
+  const fileUrl = file?.url;
+  return (
+    <>
+      <ThreadFileStatusLayOut>
+        {fileUrl ? (
+          <ThreadFileStatusElementImage image={fileUrl} />
+        ) : (
+          <ThreadMdTextSnippet />
+        )}
+      </ThreadFileStatusLayOut>
+    </>
+  );
+};
+
+export default MessageFileStatusElement;

--- a/frontend/src/components/molecules/MessageContent/MessageFileStatusElement/styles.ts
+++ b/frontend/src/components/molecules/MessageContent/MessageFileStatusElement/styles.ts
@@ -1,0 +1,29 @@
+import styled from 'styled-components';
+import ImageBox from '@atoms/ImageBox';
+import { MdTextSnippet } from 'react-icons/md';
+
+export const ThreadFileStatusLayOut = styled.div`
+  max-width: calc(100% - 5px);
+  width: 100%;
+  height: auto;
+  border: 1px solid #989898;
+  border-radius: 5px;
+  margin-right: 10px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 5px;
+`;
+
+export const ThreadFileStatusElementImage = styled(ImageBox)`
+  object-fit: contain;
+  box-sizing: content-box;
+  width: 95%;
+  border-radius: 5px;
+`;
+
+export const ThreadMdTextSnippet = styled(MdTextSnippet)`
+  width: 100%;
+  height: 100%;
+  border-radius: 5px;
+`;

--- a/frontend/src/components/molecules/MessageContent/index.tsx
+++ b/frontend/src/components/molecules/MessageContent/index.tsx
@@ -144,6 +144,7 @@ const MessageContent = ({
           messageObject={messageObject}
           channelName={channelName}
           setUpdateState={setUpdateState}
+          isInReplySide={isInReplySide}
         />
       )}
     </Container>

--- a/frontend/src/components/molecules/MessageContent/index.tsx
+++ b/frontend/src/components/molecules/MessageContent/index.tsx
@@ -1,0 +1,159 @@
+import React, { useEffect, useState } from 'react';
+import { useSetRecoilState } from 'recoil';
+import { replyToggleState } from '@state/workspace';
+import ChatInputBarForUpdate from '@organisms/ChatInputBarForUpdate';
+import ReactionBar from '@organisms/ReactionBar';
+import { userProfileModalState } from '@state/modal';
+import defaultPerson from '@global/image/default_account.png';
+import { Message } from '@global/type';
+import axios from 'axios';
+import { transfromDate } from '@global/util/transfromDate';
+import MessageActions from './MessageActions';
+import MessageFileStatusBar from './MessageFileStatusBar';
+import {
+  Container,
+  MessageKit,
+  MessageKitLeft,
+  MessageKitRight,
+  MessageSender,
+  MessageTimestamp,
+  MessageText,
+  ReplyButton,
+  MessageImageButton,
+} from './styles';
+
+interface Props {
+  messageObject: Message;
+  channelName?: string[];
+  className?: string;
+  isInReplySide?: boolean;
+}
+
+const MessageContent = ({
+  messageObject,
+  channelName,
+  className,
+  isInReplySide,
+}: Props): JSX.Element => {
+  const {
+    userHasWorkspace,
+    message,
+    createdAt,
+    id,
+    userHasWorkspaceId,
+    replys,
+    reactions,
+    files,
+  } = messageObject;
+
+  const nickname = userHasWorkspace?.nickname || '탈퇴한 유저';
+
+  const setIsUserProfileModalOpen = useSetRecoilState(userProfileModalState);
+  const [updateState, setUpdateState] = useState(false);
+  const [hoverState, setHoverState] = useState(false);
+  const [fileUrl, setFileUrl] = useState(defaultPerson);
+  const handleHoverIn = () => {
+    if (!updateState) {
+      setHoverState(true);
+    }
+  };
+  const handleHoverOut = () => {
+    if (!updateState) {
+      setHoverState(false);
+    }
+  };
+  const setReplyToggle = useSetRecoilState(replyToggleState);
+  const isReply = messageObject.threadId !== undefined;
+
+  const ordinaryMessage = (
+    <>
+      <MessageSender>{nickname}</MessageSender>
+      &nbsp; &nbsp;
+      <MessageTimestamp>{transfromDate(createdAt)}</MessageTimestamp>
+      <br />
+      <MessageText dangerouslySetInnerHTML={{ __html: message }} />
+      {reactions?.length > 0 && (
+        <ReactionBar isReply={isReply} reactions={reactions} />
+      )}
+      {!isInReplySide && replys?.length > 0 && (
+        <ReplyButton
+          onClick={() =>
+            setReplyToggle({
+              isOpened: true,
+              message: messageObject,
+              channelName,
+            })
+          }
+          text={`${replys?.length}개의 댓글`}
+        />
+      )}
+      {files?.length > 0 ? <MessageFileStatusBar files={files} /> : <></>}
+    </>
+  );
+
+  const updateMessage = (
+    <ChatInputBarForUpdate
+      messageId={id}
+      defaultMessage={message}
+      setUpdateState={setUpdateState}
+      isReply={isReply}
+    />
+  );
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  useEffect(async () => {
+    const res = await axios.get(
+      `/api/files/userhasworkspace/${userHasWorkspaceId}`,
+    );
+    if (
+      res?.data.files &&
+      res?.data.files.url &&
+      res?.data.files.url !== fileUrl
+    ) {
+      setFileUrl(res?.data.files.url);
+    }
+  }, []);
+
+  return (
+    <Container
+      className={className}
+      onMouseEnter={handleHoverIn}
+      onMouseLeave={handleHoverOut}
+      updateState={updateState}
+    >
+      <MessageKit className={updateState && 'updating'}>
+        <MessageKitLeft>
+          <MessageImageButton
+            onClick={(e) => {
+              setIsUserProfileModalOpen({
+                isOpen: true,
+                userHasWorkspace,
+                x: e.clientX,
+                y: e.clientY,
+              });
+            }}
+            image={fileUrl}
+          />
+        </MessageKitLeft>
+        <MessageKitRight>
+          {updateState ? updateMessage : ordinaryMessage}
+        </MessageKitRight>
+      </MessageKit>
+      {hoverState && !updateState && (
+        <MessageActions
+          messageObject={messageObject}
+          channelName={channelName}
+          setUpdateState={setUpdateState}
+        />
+      )}
+    </Container>
+  );
+};
+
+MessageContent.defaultProps = {
+  channelName: undefined,
+  className: '',
+  isInReplySide: false,
+};
+
+export default MessageContent;

--- a/frontend/src/components/molecules/MessageContent/styles.ts
+++ b/frontend/src/components/molecules/MessageContent/styles.ts
@@ -1,0 +1,211 @@
+import LabeledDefaultButton from '@atoms/LabeledDefaultButton';
+import styled from 'styled-components';
+import ImageButton from '@atoms/ImageButton';
+
+interface Props {
+  updateState?: boolean;
+}
+
+export const Container = styled.div<Props>`
+  width: 100%;
+  position: relative;
+
+  :hover {
+    background: ${(props) => !props.updateState && '#f8f8f8'};
+  }
+`;
+
+export const MessageImageButton = styled(ImageButton)`
+  border: 1px solid #868686;
+  border-radius: 3px;
+  width: 40px;
+  height: 40px;
+`;
+
+export const MessageKit = styled.div`
+  line-height: 1.46668;
+  padding: 8px 20px;
+  display: flex;
+
+  &.updating {
+    background: rgba(242, 199, 68, 0.2);
+  }
+`;
+
+export const MessageKitLeft = styled.div`
+  flex-shrink: 0;
+  margin-right: 8px;
+  display: flex;
+`;
+
+export const MessageKitRight = styled.div`
+  flex: 1 1 0;
+  min-width: 0;
+  height: 100%;
+  padding: 8px;
+  padding-left: 16px;
+  margin: -12px -8px -16px -16px;
+`;
+
+export const MessageSender = styled.span`
+  font-weight: 900;
+  color: #1d1c1d;
+`;
+
+export const MessageTimestamp = styled.a`
+  color: #616061;
+  font-size: 12px;
+  text-decoration: none;
+`;
+
+export const ReplyButton = styled(LabeledDefaultButton)`
+  background-color: transparent;
+  height: 10px;
+  margin: 0;
+  padding: 0;
+
+  font-size: 10px;
+  font-weight: 700;
+  border: 0;
+  flex-shrink: 0;
+  color: rgba(var(--sk_highlight, 18, 100, 163), 1);
+  text-decoration: none;
+`;
+
+export const MessageText = styled.div`
+  max-width: none;
+  margin-bottom: 8px;
+  word-wrap: break-word;
+  width: 100%;
+
+  .c-member_slug--link {
+    background: rgba(var(--sk_highlight_accent, 29, 155, 209), 0.1);
+    color: rgba(var(--sk_highlight, 18, 100, 163), 1);
+    padding: 0 2px 1px 2px;
+    border-radius: 3px;
+  }
+
+  .emoji {
+    background-position: 50% 50%;
+    background-repeat: no-repeat;
+    background-size: contain;
+    height: 22px;
+    vertical-align: bottom;
+    width: 22px;
+  }
+
+  em {
+    font-style: italic;
+  }
+
+  s {
+    text-decoration: line-through;
+  }
+
+  code {
+    --saf-0: rgba(var(--sk_foreground_low, 29, 28, 29), 0.13);
+    font-family: Monaco, Menlo, Consolas, Courier New, monospace !important;
+    font-size: 12px;
+    line-height: 1.50001;
+    font-variant-ligatures: none;
+    white-space: pre;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    word-break: normal;
+    -webkit-tab-size: 4;
+    -moz-tab-size: 4;
+    tab-size: 4;
+
+    padding: 2px 3px 1px;
+    border: 1px solid var(--saf-0);
+    border-radius: 3px;
+    background-color: rgba(var(--sk_foreground_min, 29, 28, 29), 0.04);
+    color: #e01e5a;
+  }
+
+  ul {
+    list-style: disc;
+    padding-inline-start: 26px;
+  }
+
+  ol {
+    list-style: auto;
+    padding-inline-start: 26px;
+  }
+
+  blockquote {
+    position: relative;
+    display: block;
+
+    padding-left: 16px;
+    margin-bottom: 4px;
+    margin-left: 4px;
+  }
+
+  blockquote + blockquote {
+    margin-top: -6px;
+    padding-top: 3px;
+  }
+
+  blockquote::before {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    display: block;
+    width: 4px;
+    content: '';
+    border-radius: 8px;
+    background-color: #dddddd;
+  }
+
+  .ql-code-block + .ql-code-block {
+    margin-top: -14px;
+  }
+
+  .ql-code-block {
+    position: relative;
+    border-left: 1px solid #dddddd;
+    border-right: 1px solid #dddddd;
+    padding-left: 8px;
+    padding-right: 8px;
+    margin-bottom: 14px;
+    background: #f8f8f8;
+    font-family: Monaco, Menlo, Consolas, Courier New, monospace !important;
+    font-size: 12px;
+    line-height: 1.50001;
+    font-variant-ligatures: none;
+    white-space: pre;
+    word-wrap: break-word;
+    word-break: normal;
+    tab-size: 4;
+  }
+
+  .ql-code-block::after {
+    content: '';
+    display: block;
+    position: absolute;
+    bottom: -18px;
+    left: -1px;
+    width: 100%;
+    height: 8px;
+    margin-bottom: 9px;
+    background: #f8f8f8;
+    border-bottom: 1px solid #dddddd;
+    border-left: 1px solid #dddddd;
+    border-right: 1px solid #dddddd;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+    margin-bottom: 10px;
+    width: calc(100% + 2px);
+  }
+
+  .ql-code-block:first-child,
+  *:not(.ql-code-block) + .ql-code-block {
+    margin-top: 4px;
+    padding-top: 8px;
+    border-top: 1px solid #dddddd;
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
+  }
+`;

--- a/frontend/src/components/molecules/WysiwygEditor/index.tsx
+++ b/frontend/src/components/molecules/WysiwygEditor/index.tsx
@@ -93,6 +93,10 @@ const WysiwygEditor = ({
       message.trim().length > 8) ||
     selectedFile?.length > 0;
 
+  useEffect(() => {
+    editor.current.focus();
+  }, []);
+
   return (
     <Container>
       <MessageInputArea

--- a/frontend/src/components/organisms/ChatContent/index.tsx
+++ b/frontend/src/components/organisms/ChatContent/index.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useRef } from 'react';
 import { useParams } from 'react-router-dom';
-import ThreadContent from '@molecules/ThreadContent';
+import MessageContent from '@molecules/MessageContent';
 import { usePartialThreadListQuery } from '@hook/useThreads';
-import { IThread } from '@global/type';
+import { Message } from '@global/type';
 import { useRecoilState } from 'recoil';
 import { shouldScrollDownState } from '@state/thread';
 import { Container } from './styles';
@@ -28,7 +28,7 @@ const ChatContent = ({ inputBar, channelName }: Props): JSX.Element => {
     isError,
     fetchPreviousPage,
     hasPreviousPage,
-    data: threads,
+    data: messages,
   } = usePartialThreadListQuery(channelId);
 
   useEffect(() => {
@@ -37,7 +37,7 @@ const ChatContent = ({ inputBar, channelName }: Props): JSX.Element => {
       setShouldScrollDown(false);
     }
 
-    if (!threads || !hasPreviousPage) return undefined;
+    if (!messages || !hasPreviousPage) return undefined;
     const observer = new IntersectionObserver((entries) =>
       entries.forEach((entry) => {
         if (entry.isIntersecting && hasPreviousPage) {
@@ -52,7 +52,7 @@ const ChatContent = ({ inputBar, channelName }: Props): JSX.Element => {
       observer.disconnect();
       previousRef.current?.scrollIntoView({ block: 'nearest' });
     };
-  }, [threads, hasPreviousPage]);
+  }, [messages, hasPreviousPage]);
 
   useEffect(() => {
     if (isLoading) return;
@@ -65,10 +65,10 @@ const ChatContent = ({ inputBar, channelName }: Props): JSX.Element => {
   return (
     <>
       <Container ref={currentRef}>
-        {threads.pages.flat().map((thread: IThread) => (
-          <ThreadContent
-            key={thread.id}
-            thread={thread}
+        {messages.pages.flat().map((message: Message) => (
+          <MessageContent
+            key={message.id}
+            messageObject={message}
             channelName={channelName}
           />
         ))}

--- a/frontend/src/components/organisms/ChatInputBarForUpdate/index.tsx
+++ b/frontend/src/components/organisms/ChatInputBarForUpdate/index.tsx
@@ -1,11 +1,17 @@
 import React, { Dispatch, SetStateAction, useState } from 'react';
+import { useParams } from 'react-router-dom';
 import WysiwygEditor from '@molecules/WysiwygEditor';
+import { updateReply } from '@global/api/reply';
+import { updateMessage } from '@global/api/thread';
+import { useRecoilState, useRecoilValue } from 'recoil';
+import userState from '@state/user';
+import { replyToggleState } from '@state/workspace';
 import Toolbar from './toolbar';
 import { Container, WysiwygContainer, NotificationBar } from './styles';
 
 interface Props {
   defaultMessage: string;
-  messageId: number;
+  messageId: string;
   isReply: boolean;
   setUpdateState: Dispatch<SetStateAction<boolean>>;
 }
@@ -19,6 +25,24 @@ const ChatInputBarForUpdate = ({
   const [message, setMessage] = useState('');
   const [focused, setFocused] = useState(false);
   const [messageClear, setMessageClear] = useState(false);
+  const user = useRecoilValue(userState);
+  const { channelId }: { channelId: string } = useParams();
+  const [replyToggle] = useRecoilState(replyToggleState);
+
+  const updateRequest = () => {
+    if (isReply) {
+      updateReply(
+        messageId,
+        replyToggle?.message.id,
+        channelId,
+        message,
+        user.socket,
+        setUpdateState,
+      );
+    } else {
+      updateMessage(messageId, channelId, message, user.socket, setUpdateState);
+    }
+  };
 
   return (
     <Container>
@@ -29,13 +53,12 @@ const ChatInputBarForUpdate = ({
           messageClear={messageClear}
           setMessageClear={setMessageClear}
           defaultMessage={defaultMessage}
+          onSendClick={updateRequest}
         />
         <Toolbar
-          messageId={messageId}
           message={message}
           focused={focused}
-          setUpdateState={setUpdateState}
-          isReply={isReply}
+          onSendClick={updateRequest}
         />
       </WysiwygContainer>
       <NotificationBar />

--- a/frontend/src/components/organisms/ChatInputBarForUpdate/index.tsx
+++ b/frontend/src/components/organisms/ChatInputBarForUpdate/index.tsx
@@ -5,14 +5,14 @@ import { Container, WysiwygContainer, NotificationBar } from './styles';
 
 interface Props {
   defaultMessage: string;
-  threadId: string;
+  messageId: number;
   isReply: boolean;
   setUpdateState: Dispatch<SetStateAction<boolean>>;
 }
 
 const ChatInputBarForUpdate = ({
   defaultMessage,
-  threadId,
+  messageId,
   isReply,
   setUpdateState,
 }: Props): JSX.Element => {
@@ -31,7 +31,7 @@ const ChatInputBarForUpdate = ({
           defaultMessage={defaultMessage}
         />
         <Toolbar
-          threadId={threadId}
+          messageId={messageId}
           message={message}
           focused={focused}
           setUpdateState={setUpdateState}

--- a/frontend/src/components/organisms/ChatInputBarForUpdate/toolbar/index.tsx
+++ b/frontend/src/components/organisms/ChatInputBarForUpdate/toolbar/index.tsx
@@ -1,10 +1,4 @@
-import React, { Dispatch, SetStateAction } from 'react';
-import { useRecoilValue } from 'recoil';
-import { useParams } from 'react-router-dom';
-import userState from '@state/user';
-import { replyToggleState } from '@state/workspace';
-import { updateMessage } from '@global/api/thread';
-import { updateReply } from '@global/api/reply';
+import React from 'react';
 import {
   BsTypeBold,
   BsTypeItalic,
@@ -28,45 +22,13 @@ import {
 } from './styles';
 
 interface Props {
-  messageId: number;
   message: string;
   focused: boolean;
-  setUpdateState: Dispatch<SetStateAction<boolean>>;
-  isReply: boolean;
+  onSendClick;
 }
 
-const Toolbar = ({
-  messageId,
-  message,
-  focused,
-  setUpdateState,
-  isReply,
-}: Props): JSX.Element => {
-  const { channelId }: { channelId: string } = useParams();
-  const toggleState = useRecoilValue(replyToggleState);
-  const user = useRecoilValue(userState);
+const Toolbar = ({ message, focused, onSendClick }: Props): JSX.Element => {
   const sendable = message !== '<p><br></p>' && message.length > 8;
-
-  const updateRequest = () => {
-    if (isReply) {
-      updateReply(
-        messageId,
-        toggleState?.message.id,
-        Number(channelId),
-        message,
-        user.socket,
-        setUpdateState,
-      );
-    } else {
-      updateMessage(
-        messageId,
-        Number(channelId),
-        message,
-        user.socket,
-        setUpdateState,
-      );
-    }
-  };
 
   return (
     <Container>
@@ -85,7 +47,7 @@ const Toolbar = ({
       <ToolbarSuffix>
         <ToolBarIconButton onClick={() => {}} icon={BsEmojiSmile} />
         <ToolBarIconButton
-          onClick={updateRequest}
+          onClick={onSendClick}
           icon={MdSend}
           className={sendable ? 'sendButtonActive' : 'sendButtonDisable'}
           disabled={!sendable}

--- a/frontend/src/components/organisms/ChatInputBarForUpdate/toolbar/index.tsx
+++ b/frontend/src/components/organisms/ChatInputBarForUpdate/toolbar/index.tsx
@@ -28,7 +28,7 @@ import {
 } from './styles';
 
 interface Props {
-  threadId: string;
+  messageId: number;
   message: string;
   focused: boolean;
   setUpdateState: Dispatch<SetStateAction<boolean>>;
@@ -36,7 +36,7 @@ interface Props {
 }
 
 const Toolbar = ({
-  threadId,
+  messageId,
   message,
   focused,
   setUpdateState,
@@ -50,15 +50,21 @@ const Toolbar = ({
   const updateRequest = () => {
     if (isReply) {
       updateReply(
-        threadId,
-        toggleState?.thread.id,
-        channelId,
+        messageId,
+        toggleState?.message.id,
+        Number(channelId),
         message,
         user.socket,
         setUpdateState,
       );
     } else {
-      updateMessage(threadId, channelId, message, user.socket, setUpdateState);
+      updateMessage(
+        messageId,
+        Number(channelId),
+        message,
+        user.socket,
+        setUpdateState,
+      );
     }
   };
 

--- a/frontend/src/components/organisms/ReactionBar/index.tsx
+++ b/frontend/src/components/organisms/ReactionBar/index.tsx
@@ -79,8 +79,6 @@ const ReactionBar = ({ isReply, reactions }: Props): JSX.Element => {
   const currentThreadId =
     currentReplyId === null ? reactions[0].threadId : replyToggle?.message?.id;
 
-  console.log(currentThreadId + ' : ' + currentReplyId);
-
   const emojiButtonRef = useRef(null);
   const [emojiXWidth, emojiYHeight] = useRefLocate(emojiButtonRef, 50);
   const [isEmojiOpen, setIsEmojiOpen] = useState(false);

--- a/frontend/src/components/organisms/ReactionBar/index.tsx
+++ b/frontend/src/components/organisms/ReactionBar/index.tsx
@@ -74,9 +74,12 @@ const handleEmojiClick = (
 const ReactionBar = ({ isReply, reactions }: Props): JSX.Element => {
   const user = useRecoilValue(userState);
   const { channelId }: { channelId: string } = useParams();
-  const currentThreadId = reactions[0].threadId;
-  const currentReplyId = reactions[0].replyId;
   const replyToggle = useRecoilValue(replyToggleState);
+  const currentReplyId = reactions[0].replyId;
+  const currentThreadId =
+    currentReplyId === null ? reactions[0].threadId : replyToggle?.message?.id;
+
+  console.log(currentThreadId + ' : ' + currentReplyId);
 
   const emojiButtonRef = useRef(null);
   const [emojiXWidth, emojiYHeight] = useRefLocate(emojiButtonRef, 50);

--- a/frontend/src/components/organisms/ReactionBar/index.tsx
+++ b/frontend/src/components/organisms/ReactionBar/index.tsx
@@ -55,17 +55,17 @@ const handleEmojiClick = (
     postReplyReaction(
       user.userHasWorkspaceId,
       channelId,
-      reactionMap.emoji,
-      reactionMap.list[0].replyId,
-      reactionMap.list[0].threadId,
+      String(reactionMap.emoji),
+      String(reactionMap.list[0].replyId),
+      replyToggle?.message.id,
       user.socket,
     );
   } else {
     postReaction(
       user.userHasWorkspaceId,
       channelId,
-      reactionMap.emoji,
-      reactionMap.list[0].threadId,
+      String(reactionMap.emoji),
+      String(reactionMap.list[0].threadId),
       user.socket,
     );
   }

--- a/frontend/src/components/organisms/ReactionBar/index.tsx
+++ b/frontend/src/components/organisms/ReactionBar/index.tsx
@@ -43,23 +43,18 @@ const handleEmojiClick = (
     if (isReply) {
       deleteReplyReaction(
         reacted.id,
-        Number(channelId),
+        channelId,
         replyToggle?.message.id,
         reacted.replyId,
         user.socket,
       );
     } else {
-      deleteReaction(
-        reacted.id,
-        Number(channelId),
-        reacted.threadId,
-        user.socket,
-      );
+      deleteReaction(reacted.id, channelId, reacted.threadId, user.socket);
     }
   } else if (isReply) {
     postReplyReaction(
       user.userHasWorkspaceId,
-      Number(channelId),
+      channelId,
       reactionMap.emoji,
       reactionMap.list[0].replyId,
       reactionMap.list[0].threadId,
@@ -68,7 +63,7 @@ const handleEmojiClick = (
   } else {
     postReaction(
       user.userHasWorkspaceId,
-      Number(channelId),
+      channelId,
       reactionMap.emoji,
       reactionMap.list[0].threadId,
       user.socket,
@@ -129,8 +124,8 @@ const ReactionBar = ({ isReply, reactions }: Props): JSX.Element => {
         onEmojiSet={onEmojiSet(
           user,
           isReply ? currentReplyId : currentThreadId,
-          replyToggle.message?.id,
-          Number(channelId),
+          isReply ? currentThreadId : undefined,
+          channelId,
         )}
       />
     </Container>

--- a/frontend/src/components/organisms/ReactionBar/index.tsx
+++ b/frontend/src/components/organisms/ReactionBar/index.tsx
@@ -55,8 +55,8 @@ const handleEmojiClick = (
     postReplyReaction(
       user.userHasWorkspaceId,
       channelId,
-      String(reactionMap.emoji),
-      String(reactionMap.list[0].replyId),
+      reactionMap.emoji,
+      reactionMap.list[0].replyId,
       replyToggle?.message.id,
       user.socket,
     );
@@ -64,8 +64,8 @@ const handleEmojiClick = (
     postReaction(
       user.userHasWorkspaceId,
       channelId,
-      String(reactionMap.emoji),
-      String(reactionMap.list[0].threadId),
+      reactionMap.emoji,
+      reactionMap.list[0].threadId,
       user.socket,
     );
   }

--- a/frontend/src/components/organisms/ReactionBar/index.tsx
+++ b/frontend/src/components/organisms/ReactionBar/index.tsx
@@ -4,8 +4,10 @@ import { useParams } from 'react-router-dom';
 import { BsEmojiSmileUpsideDown } from 'react-icons/bs';
 import EmojiModal from '@organisms/EmojiModal';
 import useRefLocate from '@hook/useRefLocate';
-import userState from '@state/user';
-import { replyToggleState } from '@state/workspace';
+import userState, { IUserState } from '@state/user';
+import { Reaction } from '@global/type';
+import { onEmojiSet } from '@global/util/reaction';
+import { IreplyToggle, replyToggleState } from '@state/workspace';
 import {
   deleteReaction,
   deleteReplyReaction,
@@ -16,10 +18,10 @@ import { Container, ReactionAddButton, StyledLabeledButton } from './styles';
 
 interface Props {
   isReply: boolean;
-  reactionList: unknown[];
+  reactions: Reaction[];
 }
 
-const checkUserReacted = (reaction, user) => {
+const checkUserReacted = (reaction, user: IUserState): Reaction => {
   const reacted = reaction.list.find((eachReaction) => {
     if (eachReaction.userHasWorkspaceId === user.userHasWorkspaceId) {
       return true;
@@ -29,87 +31,78 @@ const checkUserReacted = (reaction, user) => {
   return reacted;
 };
 
-const handleEmojiClick = (isReply, reaction, user, channelId, replyToggle) => {
-  const reacted = checkUserReacted(reaction, user);
+const handleEmojiClick = (
+  isReply: boolean,
+  reactionMap,
+  user: IUserState,
+  channelId: string,
+  replyToggle: IreplyToggle,
+) => {
+  const reacted = checkUserReacted(reactionMap, user);
   if (reacted) {
-    if (reacted.replyId) {
+    if (isReply) {
       deleteReplyReaction(
         reacted.id,
-        channelId,
-        replyToggle?.thread.id,
+        Number(channelId),
+        replyToggle?.message.id,
         reacted.replyId,
         user.socket,
       );
     } else {
-      deleteReaction(reacted.id, channelId, reacted.threadId, user.socket);
+      deleteReaction(
+        reacted.id,
+        Number(channelId),
+        reacted.threadId,
+        user.socket,
+      );
     }
   } else if (isReply) {
     postReplyReaction(
       user.userHasWorkspaceId,
-      channelId,
-      reaction.emoji,
-      reaction.list[0].replyId,
-      replyToggle?.thread.id,
+      Number(channelId),
+      reactionMap.emoji,
+      reactionMap.list[0].replyId,
+      reactionMap.list[0].threadId,
       user.socket,
     );
   } else {
     postReaction(
       user.userHasWorkspaceId,
-      channelId,
-      reaction.emoji,
-      reaction.list[0].threadId,
+      Number(channelId),
+      reactionMap.emoji,
+      reactionMap.list[0].threadId,
       user.socket,
     );
   }
 };
 
-const onEmojiSet = (isReply, user, replyId, threadId, channelId) => {
-  return (emoji) => {
-    if (isReply) {
-      postReplyReaction(
-        user.userHasWorkspaceId,
-        channelId,
-        emoji,
-        replyId,
-        threadId,
-        user.socket,
-      );
-    } else {
-      postReaction(
-        user.userHasWorkspaceId,
-        channelId,
-        emoji,
-        replyId,
-        user.socket,
-      );
-    }
-  };
-};
-
-const ReactionBar = ({ isReply, reactionList }: Props): JSX.Element => {
+const ReactionBar = ({ isReply, reactions }: Props): JSX.Element => {
   const user = useRecoilValue(userState);
   const { channelId }: { channelId: string } = useParams();
-  const currentThreadId = reactionList[0].threadId;
-  const currentReplyId = reactionList[0].replyId;
+  const currentThreadId = reactions[0].threadId;
+  const currentReplyId = reactions[0].replyId;
   const replyToggle = useRecoilValue(replyToggleState);
 
   const emojiButtonRef = useRef(null);
   const [emojiXWidth, emojiYHeight] = useRefLocate(emojiButtonRef, 50);
   const [isEmojiOpen, setIsEmojiOpen] = useState(false);
 
-  const reactions = [];
-  reactionList.forEach((reaction) => {
-    const temp = reactions.find(
+  const reactionList = [];
+  reactions.forEach((reaction) => {
+    const temp = reactionList.find(
       (reactionMap) => reactionMap.emoji === reaction.emoji,
     );
-    temp
-      ? temp.list.push(reaction)
-      : reactions.push({ emoji: reaction.emoji, list: [reaction] });
+
+    if (temp !== undefined) {
+      temp.list.push(reaction);
+    } else {
+      reactionList.push({ emoji: reaction.emoji, list: [reaction] });
+    }
   });
 
   return (
     <Container>
-      {reactions.map((reaction) => (
+      {reactionList.map((reaction) => (
         <StyledLabeledButton
           className={checkUserReacted(reaction, user) && 'reacted'}
           key={reaction.emoji}
@@ -134,11 +127,10 @@ const ReactionBar = ({ isReply, reactionList }: Props): JSX.Element => {
         isOpen={isEmojiOpen}
         close={() => setIsEmojiOpen(false)}
         onEmojiSet={onEmojiSet(
-          isReply,
           user,
           isReply ? currentReplyId : currentThreadId,
-          replyToggle.thread?.id,
-          channelId,
+          replyToggle.message?.id,
+          Number(channelId),
         )}
       />
     </Container>

--- a/frontend/src/components/organisms/ReplyBar/index.tsx
+++ b/frontend/src/components/organisms/ReplyBar/index.tsx
@@ -45,10 +45,8 @@ const ReplyHeader = ({ channelName, onClickX }: HeaderProps): JSX.Element => {
 
 const ReplyBar = (): JSX.Element => {
   const SIZEVW = useRecoilValue(replyWorkspaceState);
-  const [{ isOpened, thread, channelName }, setReplyToggle] =
+  const [{ isOpened, message, channelName }, setReplyToggle] =
     useRecoilState(replyToggleState);
-
-  const { id: threadId } = thread;
 
   return (
     <Container widthVW={SIZEVW} isOpened={isOpened}>
@@ -57,12 +55,12 @@ const ReplyBar = (): JSX.Element => {
         onClickX={() =>
           setReplyToggle({
             isOpened: false,
-            thread: undefined,
+            message: undefined,
             channelName: undefined,
           })
         }
       />
-      <ReplyContent thread={thread} threadId={threadId} />
+      <ReplyContent messageObject={message} />
     </Container>
   );
 };

--- a/frontend/src/components/organisms/ReplyContent/index.tsx
+++ b/frontend/src/components/organisms/ReplyContent/index.tsx
@@ -68,7 +68,7 @@ const ReplyContent = ({ messageObject }: Props): JSX.Element => {
   const ReplyList = () => {
     if (!isReplyListLoading) {
       return replyMessages?.map((reply: Message) => (
-        <MessageContent key={reply.id} messageObject={reply} />
+        <MessageContent key={reply.id} messageObject={reply} isInReplySide />
       ));
     }
 

--- a/frontend/src/components/organisms/ReplyContent/index.tsx
+++ b/frontend/src/components/organisms/ReplyContent/index.tsx
@@ -23,13 +23,13 @@ const ReplyContent = ({ messageObject }: Props): JSX.Element => {
     isLoading: isReplyLoding,
     isError: isReplyError,
     data,
-  } = useThreadQuery(String(messageObject.id));
+  } = useThreadQuery(messageObject.id);
 
   const {
     isLoading: isReplyListLoading,
     isError: isReplyListError,
     data: replyMessages,
-  } = useReplyListQuery(String(messageObject.id));
+  } = useReplyListQuery(messageObject.id);
 
   if (isReplyError || isReplyListError) return <div>error</div>;
 
@@ -49,7 +49,7 @@ const ReplyContent = ({ messageObject }: Props): JSX.Element => {
     if (sendable) {
       await postReplyAndFiles(
         userHasWorkspaceId,
-        messageObject.threadId,
+        messageObject.id,
         channelId,
         message,
         socket,

--- a/frontend/src/components/organisms/ReplyContent/index.tsx
+++ b/frontend/src/components/organisms/ReplyContent/index.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
-import ThreadContent from '@molecules/ThreadContent';
+import MessageContent from '@molecules/MessageContent';
 import ChatInputBar from '@organisms/ChatInputBar';
 import { useThreadQuery } from '@hook/useThreads';
 import { postReplyAndFiles } from '@global/api/reply';
-import { IThread } from '@global/type';
+import { Message } from '@global/type';
 import { useReplyListQuery } from '@hook/useReplys';
-
 import {
-  StyledThreadContent,
+  StyledMessageContent,
   Container,
   RowDiv,
   AbsoluteLabel,
@@ -16,22 +15,21 @@ import {
 } from './styles';
 
 interface Props {
-  thread: IThread;
-  threadId: string | number;
+  messageObject: Message;
 }
 
-const ReplyContent = ({ thread, threadId }: Props): JSX.Element => {
+const ReplyContent = ({ messageObject }: Props): JSX.Element => {
   const {
     isLoading: isReplyLoding,
     isError: isReplyError,
     data,
-  } = useThreadQuery(threadId as string);
+  } = useThreadQuery(String(messageObject.id));
 
   const {
     isLoading: isReplyListLoading,
     isError: isReplyListError,
-    data: replyThreads,
-  } = useReplyListQuery(threadId as string);
+    data: replyMessages,
+  } = useReplyListQuery(String(messageObject.id));
 
   if (isReplyError || isReplyListError) return <div>error</div>;
 
@@ -51,7 +49,7 @@ const ReplyContent = ({ thread, threadId }: Props): JSX.Element => {
     if (sendable) {
       await postReplyAndFiles(
         userHasWorkspaceId,
-        threadId,
+        messageObject.threadId,
         channelId,
         message,
         socket,
@@ -69,8 +67,8 @@ const ReplyContent = ({ thread, threadId }: Props): JSX.Element => {
 
   const ReplyList = () => {
     if (!isReplyListLoading) {
-      return replyThreads?.map((reply: IThread) => (
-        <ThreadContent key={`thread${reply.id}`} thread={reply} isReply />
+      return replyMessages?.map((reply: Message) => (
+        <MessageContent key={reply.id} messageObject={reply} />
       ));
     }
 
@@ -81,19 +79,19 @@ const ReplyContent = ({ thread, threadId }: Props): JSX.Element => {
     <>
       <Container>
         {isReplyLoding && !isReplyError && (
-          <StyledThreadContent thread={thread} isReply />
+          <StyledMessageContent messageObject={messageObject} isInReplySide />
         )}
         {!isReplyLoding && !isReplyError && (
-          <StyledThreadContent thread={data} isReply />
+          <StyledMessageContent messageObject={data} isInReplySide />
         )}
         {!isReplyListLoading && (
           <RowDiv>
-            <AbsoluteLabel text={`${replyThreads?.length ?? 0}개의 답글`} />
+            <AbsoluteLabel text={`${replyMessages?.length ?? 0}개의 답글`} />
             <GreyLine />
           </RowDiv>
         )}
         <ReplyList />
-        <ChatInputBar onSendClick={onSendClick} isReply />
+        <ChatInputBar onSendClick={onSendClick} />
         <MarginDiv />
       </Container>
     </>

--- a/frontend/src/components/organisms/ReplyContent/styles.ts
+++ b/frontend/src/components/organisms/ReplyContent/styles.ts
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import Label from '@atoms/Label';
 import MessageContent from '@molecules/MessageContent';
-import { RoundScrollBar } from '@global/mixin';
+import { RoundScrollBar } from '@global/style/mixin';
 
 interface Props {
   width?: string;

--- a/frontend/src/components/organisms/ReplyContent/styles.ts
+++ b/frontend/src/components/organisms/ReplyContent/styles.ts
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import Label from '@atoms/Label';
-import ThreadContent from '@molecules/ThreadContent';
-import { RoundScrollBar } from '@global/style/mixin';
+import MessageContent from '@molecules/MessageContent';
+import { RoundScrollBar } from '@global/mixin';
 
 interface Props {
   width?: string;
@@ -33,7 +33,7 @@ export const RowDiv = styled.div`
   margin: 2px 0 25px 0;
 `;
 
-export const StyledThreadContent = styled(ThreadContent)`
+export const StyledMessageContent = styled(MessageContent)`
   margin-top: 25px;
 `;
 

--- a/frontend/src/global/api/reaction/index.ts
+++ b/frontend/src/global/api/reaction/index.ts
@@ -62,7 +62,7 @@ export const postReplyReaction = async (
   threadId: string,
   socket: Socket,
 ): Promise<void> => {
-  const res = await axios.post(API.post.reaction.postOne, {
+  const res = await axios.post(API.post.reaction.reply, {
     userHasWorkspaceId,
     emoji,
     replyId,

--- a/frontend/src/global/api/reaction/index.ts
+++ b/frontend/src/global/api/reaction/index.ts
@@ -3,9 +3,9 @@ import { Socket } from 'socket.io-client';
 import API from '@global/api';
 
 export const deleteReaction = async (
-  reactionId: string,
-  channelId: string,
-  threadId: string,
+  reactionId: number,
+  channelId: number,
+  threadId: number,
   socket: Socket,
 ): Promise<void> => {
   const res = await axios.delete(
@@ -18,10 +18,10 @@ export const deleteReaction = async (
 };
 
 export const postReaction = async (
-  userHasWorkspaceId: string,
-  channelId: string,
+  userHasWorkspaceId: number,
+  channelId: number,
   emoji: string,
-  threadId: string,
+  threadId: number,
   socket: Socket,
 ): Promise<void> => {
   const res = await axios.post(API.post.reaction.postOne, {
@@ -36,10 +36,10 @@ export const postReaction = async (
 };
 
 export const deleteReplyReaction = async (
-  reactionId: string,
-  channelId: string,
-  threadId: string,
-  replyId: string,
+  reactionId: number,
+  channelId: number,
+  threadId: number,
+  replyId: number,
   socket: Socket,
 ): Promise<void> => {
   const res = await axios.delete(API.delete.reaction.reply, {
@@ -55,11 +55,11 @@ export const deleteReplyReaction = async (
 };
 
 export const postReplyReaction = async (
-  userHasWorkspaceId: string,
-  channelId: string,
+  userHasWorkspaceId: number,
+  channelId: number,
   emoji: string,
-  replyId: string,
-  threadId: string,
+  replyId: number,
+  threadId: number,
   socket: Socket,
 ): Promise<void> => {
   const res = await axios.post(API.post.reaction.postOne, {

--- a/frontend/src/global/api/reaction/index.ts
+++ b/frontend/src/global/api/reaction/index.ts
@@ -3,9 +3,9 @@ import { Socket } from 'socket.io-client';
 import API from '@global/api';
 
 export const deleteReaction = async (
-  reactionId: number,
-  channelId: number,
-  threadId: number,
+  reactionId: string,
+  channelId: string,
+  threadId: string,
   socket: Socket,
 ): Promise<void> => {
   const res = await axios.delete(
@@ -18,10 +18,10 @@ export const deleteReaction = async (
 };
 
 export const postReaction = async (
-  userHasWorkspaceId: number,
-  channelId: number,
+  userHasWorkspaceId: string,
+  channelId: string,
   emoji: string,
-  threadId: number,
+  threadId: string,
   socket: Socket,
 ): Promise<void> => {
   const res = await axios.post(API.post.reaction.postOne, {
@@ -36,10 +36,10 @@ export const postReaction = async (
 };
 
 export const deleteReplyReaction = async (
-  reactionId: number,
-  channelId: number,
-  threadId: number,
-  replyId: number,
+  reactionId: string,
+  channelId: string,
+  threadId: string,
+  replyId: string,
   socket: Socket,
 ): Promise<void> => {
   const res = await axios.delete(API.delete.reaction.reply, {
@@ -55,11 +55,11 @@ export const deleteReplyReaction = async (
 };
 
 export const postReplyReaction = async (
-  userHasWorkspaceId: number,
-  channelId: number,
+  userHasWorkspaceId: string,
+  channelId: string,
   emoji: string,
-  replyId: number,
-  threadId: number,
+  replyId: string,
+  threadId: string,
   socket: Socket,
 ): Promise<void> => {
   const res = await axios.post(API.post.reaction.postOne, {

--- a/frontend/src/global/api/reply/index.ts
+++ b/frontend/src/global/api/reply/index.ts
@@ -4,9 +4,9 @@ import { Socket } from 'socket.io-client';
 import API from '@global/api';
 
 export const updateReply = async (
-  replyId: number,
-  threadId: number,
-  channelId: number,
+  replyId: string,
+  threadId: string,
+  channelId: string,
   message: string,
   socket: Socket,
   setUpdateState: Dispatch<SetStateAction<boolean>>,
@@ -35,9 +35,9 @@ export const deleteReply = async (
 };
 
 export const postReply = async (
-  userHasWorkspaceId: number,
-  threadId: number,
-  channelId: number,
+  userHasWorkspaceId: string,
+  threadId: string,
+  channelId: string,
   message: string,
   socket: Socket,
   setMessageClear: Dispatch<SetStateAction<boolean>>,
@@ -55,9 +55,9 @@ export const postReply = async (
 };
 
 export const postReplyAndFiles = async (
-  userHasWorkspaceId: number,
-  threadId: number,
-  channelId: number,
+  userHasWorkspaceId: string,
+  threadId: string,
+  channelId: string,
   message: string,
   socket: Socket,
   setMessageClear: Dispatch<SetStateAction<boolean>>,

--- a/frontend/src/global/api/reply/index.ts
+++ b/frontend/src/global/api/reply/index.ts
@@ -4,9 +4,9 @@ import { Socket } from 'socket.io-client';
 import API from '@global/api';
 
 export const updateReply = async (
-  replyId: string,
-  threadId: string,
-  channelId: string,
+  replyId: number,
+  threadId: number,
+  channelId: number,
   message: string,
   socket: Socket,
   setUpdateState: Dispatch<SetStateAction<boolean>>,
@@ -35,9 +35,9 @@ export const deleteReply = async (
 };
 
 export const postReply = async (
-  userHasWorkspaceId: string,
-  threadId: string,
-  channelId: string,
+  userHasWorkspaceId: number,
+  threadId: number,
+  channelId: number,
   message: string,
   socket: Socket,
   setMessageClear: Dispatch<SetStateAction<boolean>>,
@@ -55,9 +55,9 @@ export const postReply = async (
 };
 
 export const postReplyAndFiles = async (
-  userHasWorkspaceId: string,
-  threadId: string,
-  channelId: string,
+  userHasWorkspaceId: number,
+  threadId: number,
+  channelId: number,
   message: string,
   socket: Socket,
   setMessageClear: Dispatch<SetStateAction<boolean>>,

--- a/frontend/src/global/api/thread/index.ts
+++ b/frontend/src/global/api/thread/index.ts
@@ -4,8 +4,8 @@ import { Socket } from 'socket.io-client';
 import API from '@global/api';
 
 export const updateMessage = async (
-  threadId: string,
-  channelId: string,
+  threadId: number,
+  channelId: number,
   message: string,
   socket: Socket,
   setUpdateState: Dispatch<SetStateAction<boolean>>,
@@ -33,8 +33,8 @@ export const deleteMessage = async (
 };
 
 export const postMessage = async (
-  userHasWorkspaceId: string,
-  channelId: string,
+  userHasWorkspaceId: number,
+  channelId: number,
   message: string,
   socket: Socket,
   setMessageClear: Dispatch<SetStateAction<boolean>>,
@@ -51,8 +51,8 @@ export const postMessage = async (
 };
 
 export const postMessageAndFiles = async (
-  userHasWorkspaceId: string,
-  channelId: string,
+  userHasWorkspaceId: number,
+  channelId: number,
   message: string,
   socket: Socket,
   setMessageClear: Dispatch<SetStateAction<boolean>>,

--- a/frontend/src/global/api/thread/index.ts
+++ b/frontend/src/global/api/thread/index.ts
@@ -4,8 +4,8 @@ import { Socket } from 'socket.io-client';
 import API from '@global/api';
 
 export const updateMessage = async (
-  threadId: number,
-  channelId: number,
+  threadId: string,
+  channelId: string,
   message: string,
   socket: Socket,
   setUpdateState: Dispatch<SetStateAction<boolean>>,
@@ -33,8 +33,8 @@ export const deleteMessage = async (
 };
 
 export const postMessage = async (
-  userHasWorkspaceId: number,
-  channelId: number,
+  userHasWorkspaceId: string,
+  channelId: string,
   message: string,
   socket: Socket,
   setMessageClear: Dispatch<SetStateAction<boolean>>,
@@ -51,8 +51,8 @@ export const postMessage = async (
 };
 
 export const postMessageAndFiles = async (
-  userHasWorkspaceId: number,
-  channelId: number,
+  userHasWorkspaceId: string,
+  channelId: string,
   message: string,
   socket: Socket,
   setMessageClear: Dispatch<SetStateAction<boolean>>,

--- a/frontend/src/global/api/thread/index.ts
+++ b/frontend/src/global/api/thread/index.ts
@@ -25,7 +25,7 @@ export const deleteMessage = async (
   channelId: string,
   socket: Socket,
 ): Promise<void> => {
-  const res = await axios.delete(`${API.delete.thread}${threadId}`);
+  const res = await axios.delete(`${API.delete.thread}/${threadId}`);
 
   if (res.status === 200) {
     socket.emit('threads', channelId, threadId);

--- a/frontend/src/global/type/index.ts
+++ b/frontend/src/global/type/index.ts
@@ -44,10 +44,31 @@ export interface IThread {
   userHasWorkspace: { nickname: string };
   message: string;
   createdAt: string;
-  id: string;
-  userHasWorkspaceId: string;
+  id: number;
+  userHasWorkspaceId: number;
   replys: unknown[];
   reactions: unknown[];
   files: unknown[];
   threadId?: number;
+}
+
+export interface Message {
+  userHasWorkspace: { nickname: string };
+  message: string;
+  createdAt: string;
+  id: number;
+  userHasWorkspaceId: number;
+  replys?: Message[];
+  reactions: Reaction[];
+  files: File[];
+  threadId?: number;
+}
+
+export interface Reaction {
+  createdAt: string;
+  emoji: string;
+  id: number;
+  replyId: number;
+  threadId: number;
+  userHasWorkspaceId: number;
 }

--- a/frontend/src/global/type/index.ts
+++ b/frontend/src/global/type/index.ts
@@ -4,25 +4,25 @@ export type ChannelType = '0' | '1';
 export type UserType = 'local' | 'github';
 
 export interface Workspace {
-  id: number;
+  id: string;
   profile?: string;
   name: string;
   fileId: number | null;
 }
 
 export interface Channel {
-  id: number;
+  id: string;
   name: string;
   private: ChannelType;
   description?: string;
   topic?: string;
   workspace: Workspace;
-  workspaceId: number;
+  workspaceId: string;
   createdAt: string;
 }
 
 export interface User {
-  id: number;
+  id: string;
   nickname: string;
   email: string;
   type: UserType;
@@ -30,12 +30,12 @@ export interface User {
 }
 
 export interface UserHasWorkspace {
-  id: number;
+  id: string;
   nickname: string;
   description: string;
   theme: number;
-  userId: number;
-  workspaceId: number;
+  userId: string;
+  workspaceId: string;
   fileId?: number;
   createdAt: string;
 }
@@ -44,31 +44,31 @@ export interface IThread {
   userHasWorkspace: { nickname: string };
   message: string;
   createdAt: string;
-  id: number;
-  userHasWorkspaceId: number;
+  id: string;
+  userHasWorkspaceId: string;
   replys: unknown[];
   reactions: unknown[];
   files: unknown[];
-  threadId?: number;
+  threadId?: string;
 }
 
 export interface Message {
   userHasWorkspace: { nickname: string };
   message: string;
   createdAt: string;
-  id: number;
-  userHasWorkspaceId: number;
+  id: string;
+  userHasWorkspaceId: string;
   replys?: Message[];
   reactions: Reaction[];
   files: File[];
-  threadId?: number;
+  threadId?: string;
 }
 
 export interface Reaction {
   createdAt: string;
   emoji: string;
-  id: number;
-  replyId: number;
-  threadId: number;
-  userHasWorkspaceId: number;
+  id: string;
+  replyId: string;
+  threadId: string;
+  userHasWorkspaceId: string;
 }

--- a/frontend/src/global/util/message.ts
+++ b/frontend/src/global/util/message.ts
@@ -1,0 +1,29 @@
+import { deleteReply } from '@global/api/reply';
+import { deleteMessage } from '@global/api/thread';
+import { Message } from '@global/type';
+import { IreplyToggle } from '@state/workspace';
+import { SetterOrUpdater } from 'recoil';
+import { Socket } from 'socket.io-client';
+
+export const removeMessage = (
+  messageObject: Message,
+  replyToggle: IreplyToggle,
+  setReplyToggle: SetterOrUpdater<IreplyToggle>,
+  channelId: number,
+  socket: Socket,
+): void => {
+  // 메시지 오브젝트가 스레드 아이디가 없으면 쓰레드라는 것임
+  if (!messageObject.threadId) {
+    // 지우려는 스레드가 현재 사이드에 띄워져 있는거면 닫아야함
+    if (replyToggle.message?.id === messageObject.id) {
+      setReplyToggle({
+        isOpened: false,
+        message: undefined,
+        channelName: undefined,
+      });
+    }
+    deleteMessage(messageObject.id, channelId, socket);
+  } else {
+    deleteReply(messageObject.id, replyToggle?.message.id, channelId, socket);
+  }
+};

--- a/frontend/src/global/util/message.ts
+++ b/frontend/src/global/util/message.ts
@@ -9,7 +9,7 @@ export const removeMessage = (
   messageObject: Message,
   replyToggle: IreplyToggle,
   setReplyToggle: SetterOrUpdater<IreplyToggle>,
-  channelId: number,
+  channelId: string,
   socket: Socket,
 ): void => {
   // 메시지 오브젝트가 스레드 아이디가 없으면 쓰레드라는 것임

--- a/frontend/src/global/util/reaction.ts
+++ b/frontend/src/global/util/reaction.ts
@@ -3,9 +3,9 @@ import { IUserState } from '@state/user';
 
 export const onEmojiSet = (
   user: IUserState,
-  messageId: number,
-  parentThreadId: undefined | number,
-  channelId: number,
+  messageId: string,
+  parentThreadId: undefined | string,
+  channelId: string,
 ) => {
   return (emoji: string): void => {
     if (parentThreadId !== undefined) {

--- a/frontend/src/global/util/reaction.ts
+++ b/frontend/src/global/util/reaction.ts
@@ -1,0 +1,30 @@
+import { postReaction, postReplyReaction } from '@global/api/reaction';
+import { IUserState } from '@state/user';
+
+export const onEmojiSet = (
+  user: IUserState,
+  messageId: number,
+  parentThreadId: undefined | number,
+  channelId: number,
+) => {
+  return (emoji: string): void => {
+    if (parentThreadId !== undefined) {
+      postReplyReaction(
+        user.userHasWorkspaceId,
+        channelId,
+        emoji,
+        messageId,
+        parentThreadId,
+        user.socket,
+      );
+    } else {
+      postReaction(
+        user.userHasWorkspaceId,
+        channelId,
+        emoji,
+        messageId,
+        user.socket,
+      );
+    }
+  };
+};

--- a/frontend/src/global/util/reply.ts
+++ b/frontend/src/global/util/reply.ts
@@ -1,0 +1,14 @@
+import { Message } from '@global/type';
+import { IreplyToggle } from '@state/workspace';
+
+export const checkIsInReplySide = (
+  messageObject: Message,
+  replyToggle: IreplyToggle,
+): boolean => {
+  // 현재 메시지 객체의 스레드 아이디가 존재한다면 리플라이이고
+  // 없더라도 replyToggle.message?.id === messageObject.id 라면 오른쪽 사이드바에 띄어져 있는 스레드이다.
+  return (
+    messageObject.threadId !== undefined ||
+    replyToggle.message?.id === messageObject.id
+  );
+};

--- a/frontend/src/hooks/useReplys.ts
+++ b/frontend/src/hooks/useReplys.ts
@@ -1,5 +1,6 @@
 import { useAbstractQueryList } from './useAbstract';
 
-export const useReplyListQuery = (threadId: string) => {
+export const useReplyListQuery = (_threadId: string) => {
+  const threadId = String(_threadId);
   return useAbstractQueryList('replys', threadId, { threadId });
 };

--- a/frontend/src/hooks/useSocket.ts
+++ b/frontend/src/hooks/useSocket.ts
@@ -7,8 +7,6 @@ export const initializeSocket = (socket: Socket, queryClient: QueryClient) => {
     if (!socket) return;
 
     socket.on('threads', (_channelId, _threadId) => {
-      console.log(_channelId + ' : ' + _threadId);
-
       queryClient.invalidateQueries(['threads', _channelId], {
         refetchActive: true,
       });

--- a/frontend/src/hooks/useSocket.ts
+++ b/frontend/src/hooks/useSocket.ts
@@ -6,32 +6,36 @@ export const initializeSocket = (socket: Socket, queryClient: QueryClient) => {
   useEffect(() => {
     if (!socket) return;
 
-    socket.on('threads', (_channelId, _threadId) => {
-      queryClient.invalidateQueries(['threads', _channelId], {
+    socket.on('threads', (_channelId: string, _threadId: string) => {
+      const channelId = String(_channelId);
+      const threadId = String(_threadId);
+      queryClient.invalidateQueries(['threads', channelId], {
         refetchActive: true,
       });
 
-      queryClient.invalidateQueries(['thread', _threadId], {
+      queryClient.invalidateQueries(['thread', threadId], {
         refetchActive: true,
       });
 
-      queryClient.invalidateQueries(['replys', _threadId], {
+      queryClient.invalidateQueries(['replys', threadId], {
         refetchActive: true,
       });
     });
 
     socket.on('channels', (_workspaceId) => {
-      queryClient.invalidateQueries(['channels', _workspaceId], {
+      const workspaceId = String(_workspaceId);
+      queryClient.invalidateQueries(['channels', workspaceId], {
         refetchActive: true,
       });
 
-      queryClient.invalidateQueries(['channels', 'all', _workspaceId], {
+      queryClient.invalidateQueries(['channels', 'all', workspaceId], {
         refetchActive: true,
       });
     });
 
     socket.on('channel', (_channelId) => {
-      queryClient.invalidateQueries(['channel', _channelId], {
+      const channelId = String(_channelId);
+      queryClient.invalidateQueries(['channel', channelId], {
         refetchActive: true,
       });
     });

--- a/frontend/src/hooks/useSocket.ts
+++ b/frontend/src/hooks/useSocket.ts
@@ -7,6 +7,8 @@ export const initializeSocket = (socket: Socket, queryClient: QueryClient) => {
     if (!socket) return;
 
     socket.on('threads', (_channelId, _threadId) => {
+      console.log(_channelId + ' : ' + _threadId);
+
       queryClient.invalidateQueries(['threads', _channelId], {
         refetchActive: true,
       });

--- a/frontend/src/hooks/useThreads.ts
+++ b/frontend/src/hooks/useThreads.ts
@@ -6,11 +6,13 @@ import { socketOption } from '@global/options';
 
 const MAX_THREADS = 1000000000;
 
-export const useThreadQuery = (threadId: string) => {
+export const useThreadQuery = (_threadId: string) => {
+  const threadId = String(_threadId);
   return useAbstractQuery('thread', threadId);
 };
 
-export const usePartialThreadListQuery = (channelId: string) => {
+export const usePartialThreadListQuery = (_channelId: string) => {
+  const channelId = String(_channelId);
   return useInfiniteQuery(
     ['threads', channelId],
     async ({ pageParam = MAX_THREADS }) => {

--- a/frontend/src/hooks/useUsers.ts
+++ b/frontend/src/hooks/useUsers.ts
@@ -4,9 +4,11 @@ import API from '@global/api';
 import { hourlyExpirationOption } from '@global/options';
 
 export const useUserListWithChannelInfoQuery = (
-  workspaceId: string,
-  channelId: string,
+  _workspaceId: string,
+  _channelId: string,
 ) => {
+  const workspaceId = String(_workspaceId);
+  const channelId = String(_channelId);
   return useQuery(
     ['users', channelId],
     async () => {
@@ -19,7 +21,8 @@ export const useUserListWithChannelInfoQuery = (
   );
 };
 
-export const useUsersQuery = (workspaceId: string) => {
+export const useUsersQuery = (_workspaceId: string) => {
+  const workspaceId = String(_workspaceId);
   return useQuery(
     ['users', 'all', workspaceId],
     async () => {

--- a/frontend/src/hooks/useWorkspace.ts
+++ b/frontend/src/hooks/useWorkspace.ts
@@ -3,7 +3,8 @@ import axios from 'axios';
 import API from '@global/api';
 import { hourlyExpirationOption } from '@global/options';
 
-export const useWorkspaceQuery = (workspaceId: string) => {
+export const useWorkspaceQuery = (_workspaceId: string) => {
+  const workspaceId = String(_workspaceId);
   return useQuery(
     ['workspace', workspaceId],
     async () => {

--- a/frontend/src/state/user/index.ts
+++ b/frontend/src/state/user/index.ts
@@ -4,7 +4,7 @@ import { Itheme } from '@global/theme';
 
 type ZeroOrOne = 1 | 2;
 
-interface Props {
+export interface IUserState {
   account: string;
   createdAt: Date;
   description: string;
@@ -18,7 +18,7 @@ interface Props {
   userHasWorkspaceId: number;
 }
 
-const userState = atom<Props | undefined>({
+const userState = atom<IUserState | undefined>({
   key: 'userState',
   default: undefined,
   dangerouslyAllowMutability: true,

--- a/frontend/src/state/user/index.ts
+++ b/frontend/src/state/user/index.ts
@@ -9,13 +9,13 @@ export interface IUserState {
   createdAt: Date;
   description: string;
   email: string;
-  id: number;
+  id: string;
   local: ZeroOrOne;
   nickname: string;
   password: string;
   socket: Socket;
   theme: Itheme;
-  userHasWorkspaceId: number;
+  userHasWorkspaceId: string;
 }
 
 const userState = atom<IUserState | undefined>({

--- a/frontend/src/state/workspace/index.ts
+++ b/frontend/src/state/workspace/index.ts
@@ -1,4 +1,4 @@
-import { IThread } from '@global/type';
+import { Message } from '@global/type';
 import { atom, selector } from 'recoil';
 
 const PAGEVW = 100;
@@ -13,7 +13,7 @@ export const sizestate = atom<number>({
 
 export interface IreplyToggle {
   isOpened: boolean;
-  thread: undefined | IThread;
+  message: undefined | Message;
   channelName: undefined | string[];
 }
 
@@ -21,7 +21,7 @@ export const replyToggleState = atom<IreplyToggle>({
   key: 'replyToggleState',
   default: {
     isOpened: false,
-    thread: undefined,
+    message: undefined,
     channelName: undefined,
   },
 });


### PR DESCRIPTION
## 📃 PR 제목

현재 스레드 컨텐트가 리플라이에서도 재사용되고, 인풋바도 재사용되기 때문에 이들을 사용하기 편하도록 추상화하였음.

## 📃 작업 목록

Ex) 
- [ ] Go to '...'
- [ ] Click on '....'
- [ ] Scroll down to '....'

## 📃 주의 사항

## 📃 추가 메모 사항
